### PR TITLE
Add .gitignore from .hgignore and also ignore unity generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.sublime-workspace
 
 # Xcode
-xcuserdata
+xcuserdata/
 build
 CoreAudioUtilityClasses
 CoreAudioUtilityClasses.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# OS files
+.DS_Store
+*.orig
+*.bak
+*~
+*.tmp
+*.rej
+\#*\#
+*.sublime-workspace
+
+# Xcode
+xcuserdata
+build
+CoreAudioUtilityClasses
+CoreAudioUtilityClasses.zip
+
+# Unity
+Library
+bin
+obj
+UserSettings/
+Temp/
+Logs/
+*.orig.*
+
+# VS
+*.csproj.user
+!PlatformDependent/WinRT/Tests/VSUnitTests/Assembly-CSharp/Assembly-CSharp.csproj.user
+*.suo
+*.vcxproj.user
+.vs/
+
+# VS intellisense files next to solution file for C++ projects - global configuration should perhaps place it elsewhere
+*.sdf
+
+# temporary locking file for solution access
+*.opensdf
+
+# resharper
+*.sln.DotSettings.user
+
+# MonoDevelop
+*.userprefs
+
+# ctags:
+.tags
+.tags_sorted_by_file


### PR DESCRIPTION
The repo is missing a .gitignore causing a lot of files to be shown as added that shouldn't be added to git.
This PR adds a .gitignore from the content of the .hgignore already present as well as some additional ignores for files that'll be generated when opening the project with the Unity editor.