### PR TITLE
Fix cumulative issues

### DIFF
--- a/NativeCode/AudioPluginInterface.h
+++ b/NativeCode/AudioPluginInterface.h
@@ -97,7 +97,24 @@ typedef unsigned long long UInt64;
 #           define SInt64_defined
 typedef signed long long SInt64;
 #       endif
-    #endif
+#   else // Android, ...
+#       ifndef SInt32_defined
+#           define SInt32_defined
+typedef signed int SInt32;
+#       endif
+#       ifndef UInt32_defined
+#           define UInt32_defined
+typedef unsigned int UInt32;
+#       endif
+#       ifndef UInt64_defined
+#           define UInt64_defined
+typedef unsigned long long UInt64;
+#       endif
+#       ifndef SInt64_defined
+#           define SInt64_defined
+typedef signed long long SInt64;
+#       endif
+#   endif
 #else
 #       ifndef SInt32_defined
 #           define SInt32_defined

--- a/NativeCode/AudioPluginUtil.cpp
+++ b/NativeCode/AudioPluginUtil.cpp
@@ -30,7 +30,7 @@ template<typename T>
 static void FFTProcess(UnityComplexNumber* data, int numsamples, bool forward)
 {
     unsigned int count = 1, numbits = 0;
-    while (count < (unsigned)numsamples)
+    while ((int)count < numsamples)
     {
         count += count;
         ++numbits;
@@ -261,7 +261,6 @@ void HistoryBuffer::ReadBuffer(float* buffer, int numsamplesTarget, int numsampl
     buffer[numsamplesTarget] = (float)n; // how many samples were written
 }
 
-#ifndef PLATFORM_MUTEX
 Mutex::Mutex()
 {
 #if PLATFORM_WIN
@@ -315,7 +314,6 @@ void Mutex::Unlock()
     pthread_mutex_unlock(&mutex);
 #endif
 }
-#endif
 
 void RegisterParameter(
     UnityAudioEffectDefinition& definition,
@@ -405,7 +403,7 @@ void DeclareEffect(
 #undef DECLARE_EFFECT
 
 #define DECLARE_EFFECT(namestr, ns) \
-DeclareEffect( \
+AudioPluginUtil::DeclareEffect( \
 definition[numeffects++], \
 namestr, \
 ns::CreateCallback, \
@@ -463,13 +461,13 @@ NAP_TESTSUITE(FFT)
         {
             bool highprecision = (test == 1);
 
-            Random r;
+            AudioPluginUtil::Random r;
             for (int b = 4; b <= 20; b++)
             {
                 int num = 1 << b;
 
-                UnityComplexNumber* test1 = new UnityComplexNumber[num];
-                UnityComplexNumber* test2 = new UnityComplexNumber[num];
+                AudioPluginUtil::UnityComplexNumber* test1 = new AudioPluginUtil::UnityComplexNumber[num];
+                AudioPluginUtil::UnityComplexNumber* test2 = new AudioPluginUtil::UnityComplexNumber[num];
 
                 for (int n = 0; n < num; n++)
                 {
@@ -479,8 +477,8 @@ NAP_TESTSUITE(FFT)
                     test2[n].im = test1[n].im;
                 }
 
-                FFT::Forward(test2, num, highprecision);
-                FFT::Backward(test2, num, highprecision);
+                AudioPluginUtil::FFT::Forward(test2, num, highprecision);
+                AudioPluginUtil::FFT::Backward(test2, num, highprecision);
 
                 double errtol = (highprecision) ? 1.0e-6 : 1.5e-3;
                 double maxerr = 0.0f, errsum = 0.0, rms = 0.0;

--- a/NativeCode/AudioPluginUtil.h
+++ b/NativeCode/AudioPluginUtil.h
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 
 #if PLATFORM_WIN
 #   include <windows.h>

--- a/NativeCode/AudioPluginUtil.h
+++ b/NativeCode/AudioPluginUtil.h
@@ -6,14 +6,23 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <assert.h>
 
 #if PLATFORM_WIN
 #   include <windows.h>
 #else
+#ifndef PLATFORM_MUTEX
 #   include <pthread.h>
-#   define strcpy_s strcpy
 #endif
+#   define strcpy_s strcpy
+#   define vsprintf_s vsprintf
+#endif
+
+#ifdef PLATFORM_MUTEX
+#include "PlatformMutex.h"
+#endif
+
+namespace AudioPluginUtil
+{
 
 typedef int (*InternalEffectDefinitionRegistrationCallback)(UnityAudioEffectDefinition& desc);
 
@@ -66,15 +75,15 @@ public:
     template<typename T1, typename T2, typename T3>
     inline static void Add(const UnityComplexNumberT<T1>& a, const UnityComplexNumberT<T2>& b, UnityComplexNumberT<T3>& result)
     {
-        result.re = a.re + b.re;
-        result.im = a.im + b.im;
+        result.re = static_cast<T1>(a.re + b.re);
+        result.im = static_cast<T1>(a.im + b.im);
     }
 
     template<typename T1, typename T2, typename T3>
     inline static void Sub(const UnityComplexNumberT<T1>& a, const UnityComplexNumberT<T2>& b, UnityComplexNumberT<T3>& result)
     {
-        result.re = a.re - b.re;
-        result.im = a.im - b.im;
+        result.re = static_cast<T1>(a.re - b.re);
+        result.im = static_cast<T1>(a.im - b.im);
     }
 
     template<typename T1, typename T2, typename T3>
@@ -413,8 +422,8 @@ public:
 
     inline void SetPeriod(float period, float invperiod)
     {
-        period = period;
-        invperiod = invperiod;
+        this->period = period;
+        this->invperiod = invperiod;
     }
 
     inline float Sample(Random& random)
@@ -438,6 +447,7 @@ public:
     int samplesleft;
 };
 
+#ifndef PLATFORM_MUTEX
 class Mutex
 {
 public:
@@ -454,6 +464,7 @@ protected:
     pthread_mutex_t mutex;
 #endif
 };
+#endif
 
 class MutexScopeLock
 {
@@ -493,3 +504,7 @@ void DeclareEffect(
     UnityAudioEffect_GetFloatBufferCallback getfloatbuffercallback,
     InternalEffectDefinitionRegistrationCallback registereffectdefcallback
     );
+
+} // namespace AudioPluginUtil
+
+using namespace AudioPluginUtil;

--- a/NativeCode/AudioPluginUtil.h
+++ b/NativeCode/AudioPluginUtil.h
@@ -11,15 +11,9 @@
 #if PLATFORM_WIN
 #   include <windows.h>
 #else
-#ifndef PLATFORM_MUTEX
 #   include <pthread.h>
-#endif
 #   define strcpy_s strcpy
 #   define vsprintf_s vsprintf
-#endif
-
-#ifdef PLATFORM_MUTEX
-#include "PlatformMutex.h"
 #endif
 
 namespace AudioPluginUtil
@@ -448,7 +442,6 @@ public:
     int samplesleft;
 };
 
-#ifndef PLATFORM_MUTEX
 class Mutex
 {
 public:
@@ -465,7 +458,6 @@ protected:
     pthread_mutex_t mutex;
 #endif
 };
-#endif
 
 class MutexScopeLock
 {
@@ -507,5 +499,3 @@ void DeclareEffect(
     );
 
 } // namespace AudioPluginUtil
-
-using namespace AudioPluginUtil;

--- a/NativeCode/Plugin_CorrelationMeter.cpp
+++ b/NativeCode/Plugin_CorrelationMeter.cpp
@@ -12,7 +12,7 @@ namespace CorrelationMeter
     struct EffectData
     {
         float p[P_NUM];
-        HistoryBuffer history[8];
+        AudioPluginUtil::HistoryBuffer history[8];
         int numchannels;
     };
 
@@ -20,8 +20,8 @@ namespace CorrelationMeter
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Window", "s", 0.1f, 2.0f, 0.15f, 1.0f, 1.0f, P_Window, "Length of analysis window (note: longer windows slow down framerate)");
-        RegisterParameter(definition, "Scale", "%", 0.01f, 10.0f, 1.0f, 100.0f, 1.0f, P_Scale, "Amplitude scaling for monitored signal");
+        AudioPluginUtil::RegisterParameter(definition, "Window", "s", 0.1f, 2.0f, 0.15f, 1.0f, 1.0f, P_Window, "Length of analysis window (note: longer windows slow down framerate)");
+        AudioPluginUtil::RegisterParameter(definition, "Scale", "%", 0.01f, 10.0f, 1.0f, 100.0f, 1.0f, P_Scale, "Amplitude scaling for monitored signal");
         return numparams;
     }
 
@@ -29,7 +29,7 @@ namespace CorrelationMeter
     {
         EffectData* data = new EffectData;
         memset(data, 0, sizeof(EffectData));
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
         state->effectdata = data;
         for (int i = 0; i < 8; i++)
             data->history[i].Init(state->samplerate * 2);
@@ -79,8 +79,8 @@ namespace CorrelationMeter
     int UNITY_AUDIODSP_CALLBACK GetFloatBufferCallback(UnityAudioEffectState* state, const char* name, float* buffer, int numsamples)
     {
         EffectData* data = state->GetEffectData<EffectData>();
-        HistoryBuffer& l = data->history[0];
-        HistoryBuffer& r = data->history[1];
+        AudioPluginUtil::HistoryBuffer& l = data->history[0];
+        AudioPluginUtil::HistoryBuffer& r = data->history[1];
         int w1 = l.writeindex;
         int w2 = r.writeindex;
         for (int n = 0; n < numsamples / 2; n++)

--- a/NativeCode/Plugin_Equalizer.cpp
+++ b/NativeCode/Plugin_Equalizer.cpp
@@ -72,9 +72,10 @@ namespace Equalizer
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        EffectData::Data* data = &effectdata->data;
         data->analyzer.Cleanup();
-        delete data;
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_Equalizer.cpp
+++ b/NativeCode/Plugin_Equalizer.cpp
@@ -25,13 +25,13 @@ namespace Equalizer
         struct Data
         {
             float p[P_NUM];
-            BiquadFilter FilterH[8];
-            BiquadFilter FilterP[8];
-            BiquadFilter FilterL[8];
-            BiquadFilter DisplayFilterCoeffs[3];
+            AudioPluginUtil::BiquadFilter FilterH[8];
+            AudioPluginUtil::BiquadFilter FilterP[8];
+            AudioPluginUtil::BiquadFilter FilterL[8];
+            AudioPluginUtil::BiquadFilter DisplayFilterCoeffs[3];
             float sr;
-            Random random;
-            FFTAnalyzer analyzer;
+            AudioPluginUtil::Random random;
+            AudioPluginUtil::FFTAnalyzer analyzer;
         };
         union
         {
@@ -44,19 +44,19 @@ namespace Equalizer
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "MasterGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_MasterGain, "Overall gain applied");
-        RegisterParameter(definition, "LowGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_LowGain, "Gain applied to lower frequency band");
-        RegisterParameter(definition, "MidGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_MidGain, "Gain applied to middle frequency band");
-        RegisterParameter(definition, "HighGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_HighGain, "Gain applied to high frequency band");
-        RegisterParameter(definition, "LowFreq", "Hz", 0.01f, 24000.0f, 800.0f, 1.0f, 3.0f, P_LowFreq, "Cutoff frequency of lower frequency band");
-        RegisterParameter(definition, "MidFreq", "Hz", 0.01f, 24000.0f, 4000.0f, 1.0f, 3.0f, P_MidFreq, "Center frequency of middle frequency band");
-        RegisterParameter(definition, "HighFreq", "Hz", 0.01f, 24000.0f, 8000.0f, 1.0f, 3.0f, P_HighFreq, "Cutoff frequency of high frequency band");
-        RegisterParameter(definition, "LowQ", "", 0.01f, 10.0f, 0.707f, 1.0f, 3.0f, P_LowQ, "Q-factor of lower frequency band (inversely proportional to resonance)");
-        RegisterParameter(definition, "MidQ", "", 0.01f, 10.0f, 0.707f, 1.0f, 3.0f, P_MidQ, "Q-factor of middle frequency band (inversely proportional to resonance)");
-        RegisterParameter(definition, "HighQ", "", 0.01f, 10.0f, 0.707f, 1.0f, 3.0f, P_HighQ, "Q-factor of high frequency band (inversely proportional to resonance)");
-        RegisterParameter(definition, "UseLogScale", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_UseLogScale, "Use logarithmic scale for plotting the filter curve frequency response and input/output spectra");
-        RegisterParameter(definition, "ShowSpectrum", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_ShowSpectrum, "Overlay input spectrum (green) and output spectrum (red)");
-        RegisterParameter(definition, "SpectrumDecay", "dB/s", -50.0f, 0.0f, -10.0f, 1.0f, 1.0f, P_SpectrumDecay, "Hold time for overlaid spectra");
+        AudioPluginUtil::RegisterParameter(definition, "MasterGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_MasterGain, "Overall gain applied");
+        AudioPluginUtil::RegisterParameter(definition, "LowGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_LowGain, "Gain applied to lower frequency band");
+        AudioPluginUtil::RegisterParameter(definition, "MidGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_MidGain, "Gain applied to middle frequency band");
+        AudioPluginUtil::RegisterParameter(definition, "HighGain", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_HighGain, "Gain applied to high frequency band");
+        AudioPluginUtil::RegisterParameter(definition, "LowFreq", "Hz", 0.01f, 24000.0f, 800.0f, 1.0f, 3.0f, P_LowFreq, "Cutoff frequency of lower frequency band");
+        AudioPluginUtil::RegisterParameter(definition, "MidFreq", "Hz", 0.01f, 24000.0f, 4000.0f, 1.0f, 3.0f, P_MidFreq, "Center frequency of middle frequency band");
+        AudioPluginUtil::RegisterParameter(definition, "HighFreq", "Hz", 0.01f, 24000.0f, 8000.0f, 1.0f, 3.0f, P_HighFreq, "Cutoff frequency of high frequency band");
+        AudioPluginUtil::RegisterParameter(definition, "LowQ", "", 0.01f, 10.0f, 0.707f, 1.0f, 3.0f, P_LowQ, "Q-factor of lower frequency band (inversely proportional to resonance)");
+        AudioPluginUtil::RegisterParameter(definition, "MidQ", "", 0.01f, 10.0f, 0.707f, 1.0f, 3.0f, P_MidQ, "Q-factor of middle frequency band (inversely proportional to resonance)");
+        AudioPluginUtil::RegisterParameter(definition, "HighQ", "", 0.01f, 10.0f, 0.707f, 1.0f, 3.0f, P_HighQ, "Q-factor of high frequency band (inversely proportional to resonance)");
+        AudioPluginUtil::RegisterParameter(definition, "UseLogScale", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_UseLogScale, "Use logarithmic scale for plotting the filter curve frequency response and input/output spectra");
+        AudioPluginUtil::RegisterParameter(definition, "ShowSpectrum", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_ShowSpectrum, "Overlay input spectrum (green) and output spectrum (red)");
+        AudioPluginUtil::RegisterParameter(definition, "SpectrumDecay", "dB/s", -50.0f, 0.0f, -10.0f, 1.0f, 1.0f, P_SpectrumDecay, "Hold time for overlaid spectra");
         return numparams;
     }
 
@@ -65,7 +65,7 @@ namespace Equalizer
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         effectdata->data.analyzer.spectrumSize = 4096;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         state->effectdata = effectdata;
         return UNITY_AUDIODSP_OK;
     }
@@ -98,7 +98,7 @@ namespace Equalizer
         return UNITY_AUDIODSP_OK;
     }
 
-    static void SetupFilterCoeffs(EffectData::Data* data, BiquadFilter* filterH, BiquadFilter* filterP, BiquadFilter* filterL, float samplerate)
+    static void SetupFilterCoeffs(EffectData::Data* data, AudioPluginUtil::BiquadFilter* filterH, AudioPluginUtil::BiquadFilter* filterP, AudioPluginUtil::BiquadFilter* filterL, float samplerate)
     {
         filterH->SetupHighShelf(data->p[P_HighFreq], samplerate, data->p[P_HighGain], data->p[P_HighQ]);
         filterP->SetupPeaking(data->p[P_MidFreq], samplerate, data->p[P_MidGain], data->p[P_MidQ]);

--- a/NativeCode/Plugin_ImpactGenerator.cpp
+++ b/NativeCode/Plugin_ImpactGenerator.cpp
@@ -22,7 +22,7 @@ namespace ImpactGenerator
         float bpf;
         float cut;
         float bw;
-        inline float Process(Random& random)
+        inline float Process(AudioPluginUtil::Random& random)
         {
             volume *= decay;
             lpf += cut * bpf;
@@ -38,10 +38,10 @@ namespace ImpactGenerator
 
     struct ImpactInstance
     {
-        Random random;
+        AudioPluginUtil::Random random;
         int maximpacts;
         int numimpacts;
-        RingBuffer<MAXIMPACTS, Impact> impactrb;
+        AudioPluginUtil::RingBuffer<MAXIMPACTS, Impact> impactrb;
         Impact impacts[MAXIMPACTS];
     };
 
@@ -64,10 +64,10 @@ namespace ImpactGenerator
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Instance", "", 0.0f, (float)(MAXINSTANCES - 1), 0.0f, 1.0f, 1.0f, P_INSTANCE, "Determines the instance from which impacts are received via ImpactGenerator_AddImpact");
-        RegisterParameter(definition, "Gain", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN, "Overall gain");
-        RegisterParameter(definition, "Threshold", "dB", -120.0f, 0.0f, -60.0f, 1.0f, 1.0f, P_THR, "Threshold after which impacts stop playing");
-        RegisterParameter(definition, "MaxImpacts", "", 1.0f, (float)MAXIMPACTS, 200.0f, 1.0f, 1.0f, P_MAXIMPACTS, "Maximum number of impact sounds played simultaneously on this instance");
+        AudioPluginUtil::RegisterParameter(definition, "Instance", "", 0.0f, (float)(MAXINSTANCES - 1), 0.0f, 1.0f, 1.0f, P_INSTANCE, "Determines the instance from which impacts are received via ImpactGenerator_AddImpact");
+        AudioPluginUtil::RegisterParameter(definition, "Gain", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN, "Overall gain");
+        AudioPluginUtil::RegisterParameter(definition, "Threshold", "dB", -120.0f, 0.0f, -60.0f, 1.0f, 1.0f, P_THR, "Threshold after which impacts stop playing");
+        AudioPluginUtil::RegisterParameter(definition, "MaxImpacts", "", 1.0f, (float)MAXIMPACTS, 200.0f, 1.0f, 1.0f, P_MAXIMPACTS, "Maximum number of impact sounds played simultaneously on this instance");
         return numparams;
     }
 
@@ -76,7 +76,7 @@ namespace ImpactGenerator
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_ImpactGenerator.cpp
+++ b/NativeCode/Plugin_ImpactGenerator.cpp
@@ -64,10 +64,10 @@ namespace ImpactGenerator
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Instance", "", 0.0f, MAXINSTANCES - 1, 0.0f, 1.0f, 1.0f, P_INSTANCE, "Determines the instance from which impacts are received via ImpactGenerator_AddImpact");
+        RegisterParameter(definition, "Instance", "", 0.0f, (float)(MAXINSTANCES - 1), 0.0f, 1.0f, 1.0f, P_INSTANCE, "Determines the instance from which impacts are received via ImpactGenerator_AddImpact");
         RegisterParameter(definition, "Gain", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN, "Overall gain");
         RegisterParameter(definition, "Threshold", "dB", -120.0f, 0.0f, -60.0f, 1.0f, 1.0f, P_THR, "Threshold after which impacts stop playing");
-        RegisterParameter(definition, "MaxImpacts", "", 1.0f, MAXIMPACTS, 200.0f, 1.0f, 1.0f, P_MAXIMPACTS, "Maximum number of impact sounds played simultaneously on this instance");
+        RegisterParameter(definition, "MaxImpacts", "", 1.0f, (float)MAXIMPACTS, 200.0f, 1.0f, 1.0f, P_MAXIMPACTS, "Maximum number of impact sounds played simultaneously on this instance");
         return numparams;
     }
 

--- a/NativeCode/Plugin_ImpactGenerator.cpp
+++ b/NativeCode/Plugin_ImpactGenerator.cpp
@@ -97,7 +97,7 @@ namespace ImpactGenerator
         {
             ImpactInstance* instance = GetImpactInstance((int)data->p[P_INSTANCE]);
             if (instance != NULL)
-                instance->maximpacts = value;
+                instance->maximpacts = (int)value;
         }
         return UNITY_AUDIODSP_OK;
     }

--- a/NativeCode/Plugin_ImpulseGenerator.cpp
+++ b/NativeCode/Plugin_ImpulseGenerator.cpp
@@ -23,7 +23,7 @@ namespace ImpulseGenerator
             float level;
             float decay;
             float samplesleft;
-            Random random;
+            AudioPluginUtil::Random random;
         };
         union
         {
@@ -36,14 +36,14 @@ namespace ImpulseGenerator
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Base Period", "ms", 0.0f, 5000.0f, 200.0f, 1.0f, 3.0f, P_BASEPERIOD, "Base time between impulses");
-        RegisterParameter(definition, "Random Period", "ms", 0.0f, 5000.0f, 100.0f, 1.0f, 3.0f, P_RANDOMPERIOD, "Random time between impulses");
-        RegisterParameter(definition, "Base Amp", "", 0.0f, 1.0f, 0.5f, 1.0f, 1.0f, P_BASEAMP, "Base amplitude of impulses");
-        RegisterParameter(definition, "Random Amp", "", 0.0f, 1.0f, 0.5f, 1.0f, 3.0f, P_RANDOMAMP, "Random amplitude of impulses");
-        RegisterParameter(definition, "Base Decay", "ms", 0.0f, 10000.0f, 10.0f, 1.0f, 3.0f, P_BASEDECAY, "Decay time of impulses");
-        RegisterParameter(definition, "Random Decay", "ms", 0.0f, 10000.0f, 0.0f, 1.0f, 3.0f, P_RANDOMDECAY, "Decay time of impulses");
-        RegisterParameter(definition, "Noise Level", "", 0.0f, 50.0f, 0.0f, 1.0f, 3.0f, P_NOISEADD, "Level of additive white noise");
-        RegisterParameter(definition, "Noise Mix", "", 0.0f, 1.0f, 0.0f, 1.0f, 3.0f, P_NOISEMIX, "Level of white noise multiplied by impulse");
+        AudioPluginUtil::RegisterParameter(definition, "Base Period", "ms", 0.0f, 5000.0f, 200.0f, 1.0f, 3.0f, P_BASEPERIOD, "Base time between impulses");
+        AudioPluginUtil::RegisterParameter(definition, "Random Period", "ms", 0.0f, 5000.0f, 100.0f, 1.0f, 3.0f, P_RANDOMPERIOD, "Random time between impulses");
+        AudioPluginUtil::RegisterParameter(definition, "Base Amp", "", 0.0f, 1.0f, 0.5f, 1.0f, 1.0f, P_BASEAMP, "Base amplitude of impulses");
+        AudioPluginUtil::RegisterParameter(definition, "Random Amp", "", 0.0f, 1.0f, 0.5f, 1.0f, 3.0f, P_RANDOMAMP, "Random amplitude of impulses");
+        AudioPluginUtil::RegisterParameter(definition, "Base Decay", "ms", 0.0f, 10000.0f, 10.0f, 1.0f, 3.0f, P_BASEDECAY, "Decay time of impulses");
+        AudioPluginUtil::RegisterParameter(definition, "Random Decay", "ms", 0.0f, 10000.0f, 0.0f, 1.0f, 3.0f, P_RANDOMDECAY, "Decay time of impulses");
+        AudioPluginUtil::RegisterParameter(definition, "Noise Level", "", 0.0f, 50.0f, 0.0f, 1.0f, 3.0f, P_NOISEADD, "Level of additive white noise");
+        AudioPluginUtil::RegisterParameter(definition, "Noise Mix", "", 0.0f, 1.0f, 0.0f, 1.0f, 3.0f, P_NOISEMIX, "Level of white noise multiplied by impulse");
         return numparams;
     }
 
@@ -52,7 +52,7 @@ namespace ImpulseGenerator
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 
@@ -107,7 +107,7 @@ namespace ImpulseGenerator
                 float decaytime = data->p[P_BASEDECAY] + data->random.GetFloat(0.0f, data->p[P_RANDOMDECAY]);
                 data->decay = (decaytime <= 0.0f) ? 0.0f : powf(0.001f, 1000.0f / (state->samplerate * decaytime));
                 data->level = data->p[P_BASEAMP] + data->random.GetFloat(0.0f, data->p[P_RANDOMAMP]);
-                data->samplesleft = FastMax(0.0f, data->samplesleft + (data->p[P_BASEPERIOD] + data->random.GetFloat(0.0f, data->p[P_RANDOMPERIOD])) * 0.001f * state->samplerate);
+                data->samplesleft = AudioPluginUtil::FastMax(0.0f, data->samplesleft + (data->p[P_BASEPERIOD] + data->random.GetFloat(0.0f, data->p[P_RANDOMPERIOD])) * 0.001f * state->samplerate);
             }
             float noise = data->random.GetFloat(-1.0f, 1.0f);
             float s = noise * data->p[P_NOISEADD] + data->level + data->p[P_NOISEMIX] * (noise * data->level - data->level);

--- a/NativeCode/Plugin_ImpulseGenerator.cpp
+++ b/NativeCode/Plugin_ImpulseGenerator.cpp
@@ -58,8 +58,8 @@ namespace ImpulseGenerator
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_LevelMixer.cpp
+++ b/NativeCode/Plugin_LevelMixer.cpp
@@ -54,8 +54,8 @@ namespace LevelMixer
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_LevelMixer.cpp
+++ b/NativeCode/Plugin_LevelMixer.cpp
@@ -32,14 +32,14 @@ namespace LevelMixer
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Gain1", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN1, "Gain of input channel 1 (left or mono)");
-        RegisterParameter(definition, "Gain2", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN2, "Gain of input channel 2 (right)");
-        RegisterParameter(definition, "Gain3", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN3, "Gain of input channel 3");
-        RegisterParameter(definition, "Gain4", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN4, "Gain of input channel 4");
-        RegisterParameter(definition, "Gain5", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN5, "Gain of input channel 5");
-        RegisterParameter(definition, "Gain6", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN6, "Gain of input channel 6");
-        RegisterParameter(definition, "Gain7", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN7, "Gain of input channel 7");
-        RegisterParameter(definition, "Gain8", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN8, "Gain of input channel 8");
+        AudioPluginUtil::RegisterParameter(definition, "Gain1", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN1, "Gain of input channel 1 (left or mono)");
+        AudioPluginUtil::RegisterParameter(definition, "Gain2", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN2, "Gain of input channel 2 (right)");
+        AudioPluginUtil::RegisterParameter(definition, "Gain3", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN3, "Gain of input channel 3");
+        AudioPluginUtil::RegisterParameter(definition, "Gain4", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN4, "Gain of input channel 4");
+        AudioPluginUtil::RegisterParameter(definition, "Gain5", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN5, "Gain of input channel 5");
+        AudioPluginUtil::RegisterParameter(definition, "Gain6", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN6, "Gain of input channel 6");
+        AudioPluginUtil::RegisterParameter(definition, "Gain7", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN7, "Gain of input channel 7");
+        AudioPluginUtil::RegisterParameter(definition, "Gain8", "dB", -120.0f, 50.0f, 0.0f, 1.0f, 1.0f, P_GAIN8, "Gain of input channel 8");
         return numparams;
     }
 
@@ -48,7 +48,7 @@ namespace LevelMixer
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_Lofinator.cpp
+++ b/NativeCode/Plugin_Lofinator.cpp
@@ -28,8 +28,8 @@ namespace Lofinator
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Decimation", "Hz", 0.1f, 24000.0f, 24000.0f, 1.0f, 3.0f, P_DECRATE, "Decimation rate. Determines the interval at which new samples are read and held.");
-        RegisterParameter(definition, "Quantization", "", 1.0f, 24.0f, 8.0f, 1.0f, 1.0f, P_QUANT, "Word length in bits by which the signal will be quantized.");
+        AudioPluginUtil::RegisterParameter(definition, "Decimation", "Hz", 0.1f, 24000.0f, 24000.0f, 1.0f, 3.0f, P_DECRATE, "Decimation rate. Determines the interval at which new samples are read and held.");
+        AudioPluginUtil::RegisterParameter(definition, "Quantization", "", 1.0f, 24.0f, 8.0f, 1.0f, 1.0f, P_QUANT, "Word length in bits by which the signal will be quantized.");
         return numparams;
     }
 
@@ -38,7 +38,7 @@ namespace Lofinator
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_Lofinator.cpp
+++ b/NativeCode/Plugin_Lofinator.cpp
@@ -44,8 +44,8 @@ namespace Lofinator
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_LoudnessMeter.cpp
+++ b/NativeCode/Plugin_LoudnessMeter.cpp
@@ -19,8 +19,8 @@ namespace LoudnessMeter
         float release;
         float updateperiod;
         float updatecount;
-        HistoryBuffer peakbuf;
-        HistoryBuffer rmsbuf;
+        AudioPluginUtil::HistoryBuffer peakbuf;
+        AudioPluginUtil::HistoryBuffer rmsbuf;
     public:
         void Init(float lengthInSeconds, float updateRateInHz, float attackTime, float releaseTime, float samplerate)
         {
@@ -58,7 +58,7 @@ namespace LoudnessMeter
         void ReadBuffer(float* buffer, int numsamplesTarget, float windowLength, float samplerate, bool rms)
         {
             int numsamplesSource = (int)ceilf(samplerate * windowLength / updateperiod);
-            HistoryBuffer& buf = (rms) ? rmsbuf : peakbuf;
+            AudioPluginUtil::HistoryBuffer& buf = (rms) ? rmsbuf : peakbuf;
             buf.ReadBuffer(buffer, numsamplesTarget, numsamplesSource, (float)updatecount / (float)updateperiod);
         }
     };
@@ -77,9 +77,9 @@ namespace LoudnessMeter
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Window", "s", 0.1f, kMaxWindowLength, 1.0f, 1.0f, 1.0f, P_Window, "Length of analysis window");
-        RegisterParameter(definition, "YOffset", "dB", -200.0f, 200.0f, 0.0f, 1.0f, 1.0f, P_YOffset, "Zoom offset on y-axis around which the loudness graphs will be plotted");
-        RegisterParameter(definition, "YScale", "%", 0.001f, 10.0f, 1.0f, 100.0f, 1.0f, P_YScale, "Zoom factor for loudness graph");
+        AudioPluginUtil::RegisterParameter(definition, "Window", "s", 0.1f, kMaxWindowLength, 1.0f, 1.0f, 1.0f, P_Window, "Length of analysis window");
+        AudioPluginUtil::RegisterParameter(definition, "YOffset", "dB", -200.0f, 200.0f, 0.0f, 1.0f, 1.0f, P_YOffset, "Zoom offset on y-axis around which the loudness graphs will be plotted");
+        AudioPluginUtil::RegisterParameter(definition, "YScale", "%", 0.001f, 10.0f, 1.0f, 100.0f, 1.0f, P_YScale, "Zoom factor for loudness graph");
         return numparams;
     }
 
@@ -87,7 +87,7 @@ namespace LoudnessMeter
     {
         EffectData* data = new EffectData;
         memset(data, 0, sizeof(EffectData));
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
         state->effectdata = data;
         data->momentary.Init(3.0f, (float)state->samplerate, 0.4f, 0.4f, (float)state->samplerate);
         data->shortterm.Init(kMaxWindowLength, 4.0f, 3.0f, 3.0f, (float)state->samplerate);

--- a/NativeCode/Plugin_ModalFilter.cpp
+++ b/NativeCode/Plugin_ModalFilter.cpp
@@ -33,10 +33,10 @@ namespace ModalFilter
     public:
         inline void Setup(float fFreq, float fBandwidth, float fGain)
         {
-            float fCutoff = FastClip(fFreq, 0.0001f, 0.9999f);
-            float fRadius = FastClip(1.0f - fBandwidth, 0.0001f, 0.9999f);
+            float fCutoff = AudioPluginUtil::FastClip(fFreq, 0.0001f, 0.9999f);
+            float fRadius = AudioPluginUtil::FastClip(1.0f - fBandwidth, 0.0001f, 0.9999f);
             a0 = fGain * 0.5f * (1.0f - fRadius * fRadius);
-            a1 = -2.0f * fRadius * cosf(fCutoff * kPI);
+            a1 = -2.0f * fRadius * cosf(fCutoff * AudioPluginUtil::kPI);
             a2 = fRadius * fRadius;
         }
 
@@ -64,9 +64,9 @@ namespace ModalFilter
         {
             float p[P_NUM];
             float prevp[P_NUM];
-            Random random;
+            AudioPluginUtil::Random random;
             Resonator resonators[8][MAXRESONATORS];
-            FFTAnalyzer analyzer;
+            AudioPluginUtil::FFTAnalyzer analyzer;
             float* display1;
             float* display2;
         };
@@ -81,19 +81,19 @@ namespace ModalFilter
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Random seed", "", 0.0f, 100000.0f, 0.0f, 1.0f, 1.0f, P_SEED, "Random seed, selects locations of modes and their bandwidth randomly");
-        RegisterParameter(definition, "Num modes", "", 1.0f, (float)MAXRESONATORS, 10.0f, 1.0f, 1.0f, P_NUMMODES, "Number of modes or partials");
-        RegisterParameter(definition, "Freq shift", "Hz", -3000.0f, 3000.0f, 0.0f, 1.0f, 1.0f, P_FREQSHIFT, "Frequency shift in Hz");
-        RegisterParameter(definition, "Freq shift var", "Hz", -3000.0f, 3000.0f, 0.01f, 1.0f, 1.0f, P_FREQSHIFTVAR, "Randomized frequency shift in Hz");
-        RegisterParameter(definition, "Freq scale", "", -10.0f, 10.0f, 1.0f, 1.0f, 1.0f, P_FREQSCALE, "Frequency scaling in Hz");
-        RegisterParameter(definition, "Freq scale var", "", -10.0f, 10.0f, 0.0f, 1.0, 1.0f, P_FREQSCALEVAR, "Randomized frequency scaling in Hz");
-        RegisterParameter(definition, "BW scale", "", 0.001f, 10.0f, 1.0f, 1.0f, 1.0f, P_BWSCALE, "Bandwidth scaling factor");
-        RegisterParameter(definition, "BW scale var", "", 0.001f, 10.0f, 0.001f, 1.0f, 1.0f, P_BWSCALEVAR, "Randomized bandwidth scaling factor");
-        RegisterParameter(definition, "Gain scale", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_GAINSCALE, "Gain scaling in dB");
-        RegisterParameter(definition, "Gain scale var", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_GAINSCALEVAR, "Randomized gain scaling in dB");
-        RegisterParameter(definition, "ShowSpectrum", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_SHOWSPECTRUM, "Overlay input spectrum (green) and output spectrum (red)");
-        RegisterParameter(definition, "SpectrumDecay", "dB/s", -50.0f, 0.0f, -10.0f, 1.0f, 1.0f, P_SPECTRUMDECAY, "Hold time for overlaid spectra");
-        RegisterParameter(definition, "SpectrumOffset", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_SPECTRUMOFFSET, "Spectrum drawing offset in dB");
+        AudioPluginUtil::RegisterParameter(definition, "Random seed", "", 0.0f, 100000.0f, 0.0f, 1.0f, 1.0f, P_SEED, "Random seed, selects locations of modes and their bandwidth randomly");
+        AudioPluginUtil::RegisterParameter(definition, "Num modes", "", 1.0f, (float)MAXRESONATORS, 10.0f, 1.0f, 1.0f, P_NUMMODES, "Number of modes or partials");
+        AudioPluginUtil::RegisterParameter(definition, "Freq shift", "Hz", -3000.0f, 3000.0f, 0.0f, 1.0f, 1.0f, P_FREQSHIFT, "Frequency shift in Hz");
+        AudioPluginUtil::RegisterParameter(definition, "Freq shift var", "Hz", -3000.0f, 3000.0f, 0.01f, 1.0f, 1.0f, P_FREQSHIFTVAR, "Randomized frequency shift in Hz");
+        AudioPluginUtil::RegisterParameter(definition, "Freq scale", "", -10.0f, 10.0f, 1.0f, 1.0f, 1.0f, P_FREQSCALE, "Frequency scaling in Hz");
+        AudioPluginUtil::RegisterParameter(definition, "Freq scale var", "", -10.0f, 10.0f, 0.0f, 1.0, 1.0f, P_FREQSCALEVAR, "Randomized frequency scaling in Hz");
+        AudioPluginUtil::RegisterParameter(definition, "BW scale", "", 0.001f, 10.0f, 1.0f, 1.0f, 1.0f, P_BWSCALE, "Bandwidth scaling factor");
+        AudioPluginUtil::RegisterParameter(definition, "BW scale var", "", 0.001f, 10.0f, 0.001f, 1.0f, 1.0f, P_BWSCALEVAR, "Randomized bandwidth scaling factor");
+        AudioPluginUtil::RegisterParameter(definition, "Gain scale", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_GAINSCALE, "Gain scaling in dB");
+        AudioPluginUtil::RegisterParameter(definition, "Gain scale var", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_GAINSCALEVAR, "Randomized gain scaling in dB");
+        AudioPluginUtil::RegisterParameter(definition, "ShowSpectrum", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_SHOWSPECTRUM, "Overlay input spectrum (green) and output spectrum (red)");
+        AudioPluginUtil::RegisterParameter(definition, "SpectrumDecay", "dB/s", -50.0f, 0.0f, -10.0f, 1.0f, 1.0f, P_SPECTRUMDECAY, "Hold time for overlaid spectra");
+        AudioPluginUtil::RegisterParameter(definition, "SpectrumOffset", "dB", -100.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_SPECTRUMOFFSET, "Spectrum drawing offset in dB");
         return numparams;
     }
 
@@ -105,7 +105,7 @@ namespace ModalFilter
         effectdata->data.analyzer.spectrumSize = 4096;
         effectdata->data.display1 = new float[MAXRESONATORS * 3];
         effectdata->data.display2 = new float[MAXRESONATORS * 3];
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_ModalFilter.cpp
+++ b/NativeCode/Plugin_ModalFilter.cpp
@@ -111,11 +111,12 @@ namespace ModalFilter
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        EffectData::Data* data = &effectdata->data;
         data->analyzer.Cleanup();
         delete[] data->display1;
         delete[] data->display2;
-        delete data;
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_ModalFilter.cpp
+++ b/NativeCode/Plugin_ModalFilter.cpp
@@ -82,7 +82,7 @@ namespace ModalFilter
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
         RegisterParameter(definition, "Random seed", "", 0.0f, 100000.0f, 0.0f, 1.0f, 1.0f, P_SEED, "Random seed, selects locations of modes and their bandwidth randomly");
-        RegisterParameter(definition, "Num modes", "", 1.0f, MAXRESONATORS, 10.0f, 1.0f, 1.0f, P_NUMMODES, "Number of modes or partials");
+        RegisterParameter(definition, "Num modes", "", 1.0f, (float)MAXRESONATORS, 10.0f, 1.0f, 1.0f, P_NUMMODES, "Number of modes or partials");
         RegisterParameter(definition, "Freq shift", "Hz", -3000.0f, 3000.0f, 0.0f, 1.0f, 1.0f, P_FREQSHIFT, "Frequency shift in Hz");
         RegisterParameter(definition, "Freq shift var", "Hz", -3000.0f, 3000.0f, 0.01f, 1.0f, 1.0f, P_FREQSHIFTVAR, "Randomized frequency shift in Hz");
         RegisterParameter(definition, "Freq scale", "", -10.0f, 10.0f, 1.0f, 1.0f, 1.0f, P_FREQSCALE, "Frequency scaling in Hz");

--- a/NativeCode/Plugin_Multiband.cpp
+++ b/NativeCode/Plugin_Multiband.cpp
@@ -142,9 +142,10 @@ namespace Multiband
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        EffectData::Data* data = &effectdata->data;
         data->analyzer.Cleanup();
-        delete data;
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 
@@ -170,10 +171,10 @@ namespace Multiband
     static void SetupFilterCoeffs(EffectData::Data* data, int samplerate, BiquadFilter* filter0, BiquadFilter* filter1, BiquadFilter* filter2, BiquadFilter* filter3)
     {
         const float qfactor = 0.707f;
-        filter0->SetupLowpass(data->p[P_LowFreq], samplerate, qfactor);
-        filter1->SetupHighpass(data->p[P_LowFreq], samplerate, qfactor);
-        filter2->SetupLowpass(data->p[P_HighFreq], samplerate, qfactor);
-        filter3->SetupHighpass(data->p[P_HighFreq], samplerate, qfactor);
+        filter0->SetupLowpass(data->p[P_LowFreq], (float)samplerate, qfactor);
+        filter1->SetupHighpass(data->p[P_LowFreq], (float)samplerate, qfactor);
+        filter2->SetupLowpass(data->p[P_HighFreq], (float)samplerate, qfactor);
+        filter3->SetupHighpass(data->p[P_HighFreq], (float)samplerate, qfactor);
     }
 
     int UNITY_AUDIODSP_CALLBACK GetFloatBufferCallback(UnityAudioEffectState* state, const char* name, float* buffer, int numsamples)

--- a/NativeCode/Plugin_NoiseBox.cpp
+++ b/NativeCode/Plugin_NoiseBox.cpp
@@ -20,7 +20,7 @@ namespace NoiseBox
             float addnoise;
             float mulcount;
             float mulnoise;
-            Random random;
+            AudioPluginUtil::Random random;
         };
         union
         {
@@ -33,10 +33,10 @@ namespace NoiseBox
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Add Amount", "dB", -100.0f, 0.0f, -50.0f, 1.0f, 1.0f, P_ADDAMT, "Gain of additive noise in dB");
-        RegisterParameter(definition, "Mul Amount", "dB", -100.0f, 0.0f, -50.0f, 1.0f, 1.0f, P_MULAMT, "Gain of multiplicative noise in dB");
-        RegisterParameter(definition, "Add Frequency", "Hz", 0.001f, 24000.0f, 5000.0f, 1.0f, 3.0f, P_ADDFREQ, "Additive noise frequency cutoff in Hz");
-        RegisterParameter(definition, "Mul Frequency", "Hz", 0.001f, 24000.0f, 50.0f, 1.0f, 3.0f, P_MULFREQ, "Multiplicative noise frequency cutoff in Hz");
+        AudioPluginUtil::RegisterParameter(definition, "Add Amount", "dB", -100.0f, 0.0f, -50.0f, 1.0f, 1.0f, P_ADDAMT, "Gain of additive noise in dB");
+        AudioPluginUtil::RegisterParameter(definition, "Mul Amount", "dB", -100.0f, 0.0f, -50.0f, 1.0f, 1.0f, P_MULAMT, "Gain of multiplicative noise in dB");
+        AudioPluginUtil::RegisterParameter(definition, "Add Frequency", "Hz", 0.001f, 24000.0f, 5000.0f, 1.0f, 3.0f, P_ADDFREQ, "Additive noise frequency cutoff in Hz");
+        AudioPluginUtil::RegisterParameter(definition, "Mul Frequency", "Hz", 0.001f, 24000.0f, 50.0f, 1.0f, 3.0f, P_MULFREQ, "Multiplicative noise frequency cutoff in Hz");
         return numparams;
     }
 
@@ -45,7 +45,7 @@ namespace NoiseBox
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_NoiseBox.cpp
+++ b/NativeCode/Plugin_NoiseBox.cpp
@@ -51,8 +51,8 @@ namespace NoiseBox
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_Oscilloscope.cpp
+++ b/NativeCode/Plugin_Oscilloscope.cpp
@@ -16,10 +16,10 @@ namespace Oscilloscope
     struct EffectData
     {
         float p[P_NUM];
-        HistoryBuffer history[8];
-        HistoryBuffer spectrum[8];
+        AudioPluginUtil::HistoryBuffer history[8];
+        AudioPluginUtil::HistoryBuffer spectrum[8];
         int numchannels;
-        UnityComplexNumber fftbuf[FFTSIZE];
+        AudioPluginUtil::UnityComplexNumber fftbuf[FFTSIZE];
         float smoothspec[8][FFTSIZE];
     };
 
@@ -27,10 +27,10 @@ namespace Oscilloscope
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Window", "s", 0.01f, 2.0f, 0.1f, 1.0f, 3.0f, P_Window, "Length of analysis window");
-        RegisterParameter(definition, "Scale", "%", 0.01f, 10.0f, 1.0f, 100.0f, 3.0f, P_Scale, "Amplitude scaling for monitored signal");
-        RegisterParameter(definition, "Mode", "", 0.0f, 3.0f, 0.0f, 1.0f, 1.0f, P_Mode, "Display mode (0=scope, 1=spectrum, 2=spectrogram)");
-        RegisterParameter(definition, "SpectrumDecay", "dB/s", -100.0f, 0.0f, -10.0f, 1.0f, 1.0f, P_SpectrumDecay, "Hold time for overlaid spectra");
+        AudioPluginUtil::RegisterParameter(definition, "Window", "s", 0.01f, 2.0f, 0.1f, 1.0f, 3.0f, P_Window, "Length of analysis window");
+        AudioPluginUtil::RegisterParameter(definition, "Scale", "%", 0.01f, 10.0f, 1.0f, 100.0f, 3.0f, P_Scale, "Amplitude scaling for monitored signal");
+        AudioPluginUtil::RegisterParameter(definition, "Mode", "", 0.0f, 3.0f, 0.0f, 1.0f, 1.0f, P_Mode, "Display mode (0=scope, 1=spectrum, 2=spectrogram)");
+        AudioPluginUtil::RegisterParameter(definition, "SpectrumDecay", "dB/s", -100.0f, 0.0f, -10.0f, 1.0f, 1.0f, P_SpectrumDecay, "Hold time for overlaid spectra");
         return numparams;
     }
 
@@ -38,7 +38,7 @@ namespace Oscilloscope
     {
         EffectData* data = new EffectData;
         memset(data, 0, sizeof(EffectData));
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
         state->effectdata = data;
         for (int i = 0; i < 8; i++)
         {
@@ -68,12 +68,12 @@ namespace Oscilloscope
         {
             for (int i = 0; i < inchannels; i++)
             {
-                HistoryBuffer& history = data->history[i];
-                HistoryBuffer& spectrum = data->spectrum[i];
+                AudioPluginUtil::HistoryBuffer& history = data->history[i];
+                AudioPluginUtil::HistoryBuffer& spectrum = data->spectrum[i];
                 int windowsize = FFTSIZE / 2;
                 int w = history.writeindex;
-                float c = 1.0f, s = 0.0f, f = 2.0f * sinf(kPI / (float)windowsize);
-                memset(data->fftbuf, 0, sizeof(UnityComplexNumber) * FFTSIZE);
+                float c = 1.0f, s = 0.0f, f = 2.0f * sinf(AudioPluginUtil::kPI / (float)windowsize);
+                memset(data->fftbuf, 0, sizeof(AudioPluginUtil::UnityComplexNumber) * FFTSIZE);
                 for (int n = 0; n < windowsize; n++)
                 {
                     data->fftbuf[n].re = history.data[w] * (0.5f - 0.5f * c);
@@ -82,7 +82,7 @@ namespace Oscilloscope
                     if (--w < 0)
                         w = history.length - 1;
                 }
-                FFT::Forward(data->fftbuf, FFTSIZE, true);
+                AudioPluginUtil::FFT::Forward(data->fftbuf, FFTSIZE, true);
                 float specdecay = powf(10.0f, 0.05f * data->p[P_SpectrumDecay] * length / (float)state->samplerate);
                 for (int n = 0; n < FFTSIZE / 2; n++)
                 {

--- a/NativeCode/Plugin_PitchDetector.cpp
+++ b/NativeCode/Plugin_PitchDetector.cpp
@@ -34,7 +34,7 @@ namespace PitchDetector
             float buffer[WINSIZE];
             float window[WINSIZE];
             float acnf[FFTSIZE];
-            UnityComplexNumber spec[FFTSIZE];
+            AudioPluginUtil::UnityComplexNumber spec[FFTSIZE];
         };
         union
         {
@@ -47,14 +47,14 @@ namespace PitchDetector
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Index", "", 0.0f, MAXINDEX - 1, 0.0f, 1.0f, 1.0f, P_INDEX, "Determines where the pitch data is written to for access by scripts via PitchDetectorGetFreq");
-        RegisterParameter(definition, "Low Cut", "", 0.0f, (FFTSIZE / 2) - 1, 20, 1.0f, 1.0f, P_LOCUT, "Low frequency cut-off for input preprocessing");
-        RegisterParameter(definition, "High Cut", "", 0.0f, (FFTSIZE / 2) - 1, 1000, 1.0f, 1.0f, P_HICUT, "High frequency cut-off for input preprocessing");
-        RegisterParameter(definition, "Low Bin", "", 0.0f, (FFTSIZE / 2) - 1, 50, 1.0f, 1.0f, P_LOBIN, "Low detection bin in autocorrelation");
-        RegisterParameter(definition, "High Bin", "", 0.0f, (FFTSIZE / 2) - 1, 1500, 1.0f, 1.0f, P_HIBIN, "High detection bin in autocorrelation");
-        RegisterParameter(definition, "Threshold", "%", 0.0f, 1.0f, 0.05f, 1.0f, 1.0f, P_THR, "Input signal envelope threshold above which pitch detection is attempted");
-        RegisterParameter(definition, "Osc Pitch", "", -48.0f, 48.0f, 0.0f, 1.0f, 1.0f, P_OSCPITCH, "Relative oscillator pitch in semitones");
-        RegisterParameter(definition, "Monitor", "%", 0.0f, 1.0f, 0.5f, 100.0f, 1.0f, P_MONITOR, "Monitor mix for auditioning the pitch tracking");
+        AudioPluginUtil::RegisterParameter(definition, "Index", "", 0.0f, MAXINDEX - 1, 0.0f, 1.0f, 1.0f, P_INDEX, "Determines where the pitch data is written to for access by scripts via PitchDetectorGetFreq");
+        AudioPluginUtil::RegisterParameter(definition, "Low Cut", "", 0.0f, (FFTSIZE / 2) - 1, 20, 1.0f, 1.0f, P_LOCUT, "Low frequency cut-off for input preprocessing");
+        AudioPluginUtil::RegisterParameter(definition, "High Cut", "", 0.0f, (FFTSIZE / 2) - 1, 1000, 1.0f, 1.0f, P_HICUT, "High frequency cut-off for input preprocessing");
+        AudioPluginUtil::RegisterParameter(definition, "Low Bin", "", 0.0f, (FFTSIZE / 2) - 1, 50, 1.0f, 1.0f, P_LOBIN, "Low detection bin in autocorrelation");
+        AudioPluginUtil::RegisterParameter(definition, "High Bin", "", 0.0f, (FFTSIZE / 2) - 1, 1500, 1.0f, 1.0f, P_HIBIN, "High detection bin in autocorrelation");
+        AudioPluginUtil::RegisterParameter(definition, "Threshold", "%", 0.0f, 1.0f, 0.05f, 1.0f, 1.0f, P_THR, "Input signal envelope threshold above which pitch detection is attempted");
+        AudioPluginUtil::RegisterParameter(definition, "Osc Pitch", "", -48.0f, 48.0f, 0.0f, 1.0f, 1.0f, P_OSCPITCH, "Relative oscillator pitch in semitones");
+        AudioPluginUtil::RegisterParameter(definition, "Monitor", "%", 0.0f, 1.0f, 0.5f, 100.0f, 1.0f, P_MONITOR, "Monitor mix for auditioning the pitch tracking");
         return numparams;
     }
 
@@ -67,18 +67,18 @@ namespace PitchDetector
         EffectData::Data* data = &effectdata->data;
         for (int i = 0; i < WINSIZE; i++)
         {
-            float w = 0.5f - 0.5f * cosf(i * kPI / (float)WINSIZE);
+            float w = 0.5f - 0.5f * cosf(i * AudioPluginUtil::kPI / (float)WINSIZE);
             data->window[i] = w;
             data->spec[i].re = w;
         }
 
         // Window correction
-        FFT::Forward(data->spec, FFTSIZE, true);
+        AudioPluginUtil::FFT::Forward(data->spec, FFTSIZE, true);
         for (int i = 0; i < FFTSIZE; i++)
             data->acnf[i] = 1.0f / data->spec[i].Magnitude2();
 
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 
@@ -150,13 +150,13 @@ namespace PitchDetector
                     data->spec[i].im = 0.0f;
                 }
 
-                FFT::Forward(data->spec, FFTSIZE, true);
+                AudioPluginUtil::FFT::Forward(data->spec, FFTSIZE, true);
 
                 int locut = (int)data->p[P_LOCUT];
                 int hicut = (int)data->p[P_HICUT];
-                memset(data->spec, 0, sizeof(UnityComplexNumber) * locut);
-                memset(data->spec + hicut, 0, sizeof(UnityComplexNumber) * (FFTSIZE - 2 * hicut));
-                memset(data->spec + FFTSIZE - locut, 0, sizeof(UnityComplexNumber) * locut);
+                memset(data->spec, 0, sizeof(AudioPluginUtil::UnityComplexNumber) * locut);
+                memset(data->spec + hicut, 0, sizeof(AudioPluginUtil::UnityComplexNumber) * (FFTSIZE - 2 * hicut));
+                memset(data->spec + FFTSIZE - locut, 0, sizeof(AudioPluginUtil::UnityComplexNumber) * locut);
 
                 // Fast autocorrelation
                 for (int i = 0; i < FFTSIZE; i++)
@@ -165,7 +165,7 @@ namespace PitchDetector
                     data->spec[i].im = 0.0f;
                     debugdata[i] = data->spec[i].re;
                 }
-                FFT::Backward(data->spec, FFTSIZE, true);
+                AudioPluginUtil::FFT::Backward(data->spec, FFTSIZE, true);
 
                 int startbin = (int)data->p[P_LOBIN];
                 int endbin = (int)data->p[P_HIBIN];
@@ -186,7 +186,7 @@ namespace PitchDetector
             }
 
             data->phase += detected_freqs[(int)data->p[P_INDEX]] * oscpitch;
-            data->phase -= FastFloor(data->phase);
+            data->phase -= AudioPluginUtil::FastFloor(data->phase);
 
             for (int c = 0; c < outchannels; c++)
                 outbuffer[n * outchannels + c] += ((data->phase * 2.0f - 1.0f) * data->env - outbuffer[n * outchannels + c]) * monitor;

--- a/NativeCode/Plugin_PitchDetector.cpp
+++ b/NativeCode/Plugin_PitchDetector.cpp
@@ -84,8 +84,8 @@ namespace PitchDetector
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_RingModulator.cpp
+++ b/NativeCode/Plugin_RingModulator.cpp
@@ -45,8 +45,8 @@ namespace RingModulator
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_RingModulator.cpp
+++ b/NativeCode/Plugin_RingModulator.cpp
@@ -28,8 +28,8 @@ namespace RingModulator
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Frequency", "Hz", 0.0f, kMaxSampleRate, 1000.0f, 1.0f, 3.0f, P_FREQ, "Frequency of sine oscillator that is multiplied with the input signal");
-        RegisterParameter(definition, "Mix amount", "", 0.0f, 1.0f, 0.5f, 1.0f, 1.0f, P_MIX, "Ratio between input and ring-modulated signals");
+        AudioPluginUtil::RegisterParameter(definition, "Frequency", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 1000.0f, 1.0f, 3.0f, P_FREQ, "Frequency of sine oscillator that is multiplied with the input signal");
+        AudioPluginUtil::RegisterParameter(definition, "Mix amount", "", 0.0f, 1.0f, 0.5f, 1.0f, 1.0f, P_MIX, "Ratio between input and ring-modulated signals");
         return numparams;
     }
 
@@ -39,7 +39,7 @@ namespace RingModulator
         memset(effectdata, 0, sizeof(EffectData));
         effectdata->data.c = 1.0f;
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 
@@ -79,7 +79,7 @@ namespace RingModulator
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ProcessCallback(UnityAudioEffectState* state, float* inbuffer, float* outbuffer, unsigned int length, int inchannels, int outchannels)
     {
         EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        float w = 2.0f * sinf(kPI * data->p[P_FREQ] / state->samplerate);
+        float w = 2.0f * sinf(AudioPluginUtil::kPI * data->p[P_FREQ] / state->samplerate);
         for (unsigned int n = 0; n < length; n++)
         {
             for (int i = 0; i < outchannels; i++)

--- a/NativeCode/Plugin_Routing.cpp
+++ b/NativeCode/Plugin_Routing.cpp
@@ -11,7 +11,7 @@ namespace Routing
     };
 
     int bufferchannels[MAXINDEX];
-    RingBuffer<65536> buffer[MAXINDEX];
+    AudioPluginUtil::RingBuffer<65536> buffer[MAXINDEX];
 
     struct EffectData
     {
@@ -22,7 +22,7 @@ namespace Routing
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Target", "", 0.0f, MAXINDEX - 1, 0.0f, 1.0f, 1.0f, P_TARGET, "Specifies the output that the input signal is routed to. This can be read by scripts via RoutingDemo_GetData");
+        AudioPluginUtil::RegisterParameter(definition, "Target", "", 0.0f, MAXINDEX - 1, 0.0f, 1.0f, 1.0f, P_TARGET, "Specifies the output that the input signal is routed to. This can be read by scripts via RoutingDemo_GetData");
         for (int i = 0; i < MAXINDEX; i++)
             buffer[i].Clear();
         return numparams;
@@ -33,7 +33,7 @@ namespace Routing
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_Spatializer.cpp
+++ b/NativeCode/Plugin_Spatializer.cpp
@@ -239,7 +239,7 @@ namespace Spatializer
         float spreadmatrix[2] = { 2.0f - spread, spread };
 
         float* reverb = reverbmixbuffer;
-        for (int sampleOffset = 0; sampleOffset < length; sampleOffset += HRTFLEN)
+        for (unsigned int sampleOffset = 0; sampleOffset < length; sampleOffset += HRTFLEN)
         {
             for (int c = 0; c < 2; c++)
             {

--- a/NativeCode/Plugin_Spatializer.cpp
+++ b/NativeCode/Plugin_Spatializer.cpp
@@ -27,7 +27,7 @@ namespace Spatializer
             float* hrtf;
             float* angles;
 
-            void GetHRTF(UnityComplexNumber* h, float angle, float mix)
+            void GetHRTF(AudioPluginUtil::UnityComplexNumber* h, float angle, float mix)
             {
                 int index1 = 0;
                 while (index1 < numangles && angles[index1] < angle)
@@ -65,14 +65,14 @@ namespace Spatializer
                     p += coeffs.numangles;
                     coeffs.hrtf = new float[coeffs.numangles * HRTFLEN * 4];
                     float* dst = coeffs.hrtf;
-                    UnityComplexNumber h[HRTFLEN * 2];
+                    AudioPluginUtil::UnityComplexNumber h[HRTFLEN * 2];
                     for (int a = 0; a < coeffs.numangles; a++)
                     {
                         memset(h, 0, sizeof(h));
                         for (int n = 0; n < HRTFLEN; n++)
                             h[n + HRTFLEN].re = p[n];
                         p += HRTFLEN;
-                        FFT::Forward(h, HRTFLEN * 2, false);
+                        AudioPluginUtil::FFT::Forward(h, HRTFLEN * 2, false);
                         for (int n = 0; n < HRTFLEN * 2; n++)
                         {
                             *dst++ = h[n].re;
@@ -88,9 +88,9 @@ namespace Spatializer
 
     struct InstanceChannel
     {
-        UnityComplexNumber h[HRTFLEN * 2];
-        UnityComplexNumber x[HRTFLEN * 2];
-        UnityComplexNumber y[HRTFLEN * 2];
+        AudioPluginUtil::UnityComplexNumber h[HRTFLEN * 2];
+        AudioPluginUtil::UnityComplexNumber x[HRTFLEN * 2];
+        AudioPluginUtil::UnityComplexNumber y[HRTFLEN * 2];
         float buffer[HRTFLEN * 2];
     };
 
@@ -113,9 +113,9 @@ namespace Spatializer
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "AudioSrc Attn", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_AUDIOSRCATTN, "AudioSource distance attenuation");
-        RegisterParameter(definition, "Fixed Volume", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_FIXEDVOLUME, "Fixed volume amount");
-        RegisterParameter(definition, "Custom Falloff", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_CUSTOMFALLOFF, "Custom volume falloff amount (logarithmic)");
+        AudioPluginUtil::RegisterParameter(definition, "AudioSrc Attn", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_AUDIOSRCATTN, "AudioSource distance attenuation");
+        AudioPluginUtil::RegisterParameter(definition, "Fixed Volume", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_FIXEDVOLUME, "Fixed volume amount");
+        AudioPluginUtil::RegisterParameter(definition, "Custom Falloff", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_CUSTOMFALLOFF, "Custom volume falloff amount (logarithmic)");
         definition.flags |= UnityAudioEffectDefinitionFlags_IsSpatializer;
         return numparams;
     }
@@ -126,7 +126,7 @@ namespace Spatializer
         *attenuationOut =
             data->p[P_AUDIOSRCATTN] * attenuationIn +
             data->p[P_FIXEDVOLUME] +
-            data->p[P_CUSTOMFALLOFF] * (1.0f / FastMax(1.0f, distanceIn));
+            data->p[P_CUSTOMFALLOFF] * (1.0f / AudioPluginUtil::FastMax(1.0f, distanceIn));
         return UNITY_AUDIODSP_OK;
     }
 
@@ -137,7 +137,7 @@ namespace Spatializer
         state->effectdata = effectdata;
         if (IsHostCompatible(state))
             state->spatializerdata->distanceattenuationcallback = DistanceAttenuationCallback;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
         return UNITY_AUDIODSP_OK;
     }
 
@@ -174,9 +174,9 @@ namespace Spatializer
         return UNITY_AUDIODSP_OK;
     }
 
-    static void GetHRTF(int channel, UnityComplexNumber* h, float azimuth, float elevation)
+    static void GetHRTF(int channel, AudioPluginUtil::UnityComplexNumber* h, float azimuth, float elevation)
     {
-        float e = FastClip(elevation * 0.1f + 4, 0, 12);
+        float e = AudioPluginUtil::FastClip(elevation * 0.1f + 4, 0, 12);
         float f = floorf(e);
         int index1 = (int)f;
         if (index1 < 0)
@@ -202,7 +202,7 @@ namespace Spatializer
 
         EffectData* data = state->GetEffectData<EffectData>();
 
-        static const float kRad2Deg = 180.0f / kPI;
+        static const float kRad2Deg = 180.0f / AudioPluginUtil::kPI;
 
         float* m = state->spatializerdata->listenermatrix;
         float* s = state->spatializerdata->sourcematrix;
@@ -218,8 +218,8 @@ namespace Spatializer
 
         float azimuth = (fabsf(dir_z) < 0.001f) ? 0.0f : atan2f(dir_x, dir_z);
         if (azimuth < 0.0f)
-            azimuth += 2.0f * kPI;
-        azimuth = FastClip(azimuth * kRad2Deg, 0.0f, 360.0f);
+            azimuth += 2.0f * AudioPluginUtil::kPI;
+        azimuth = AudioPluginUtil::FastClip(azimuth * kRad2Deg, 0.0f, 360.0f);
 
         float elevation = atan2f(dir_y, sqrtf(dir_x * dir_x + dir_z * dir_z) + 0.001f) * kRad2Deg;
         float spatialblend = state->spatializerdata->spatialblend;
@@ -235,7 +235,7 @@ namespace Spatializer
         //   A spread angle of 360 makes the stereo sound mono at the opposite speaker location to where the 3D emitter should be located (by moving the left part 180 degrees left and the right part 180 degrees right). So in this case, behind you when the sound should be in front of you!
         // Note that FMOD performs the spreading and panning in one go. We can't do this here due to the way that impulse-based spatialization works, so we perform the spread calculations on the left/right source signals before they enter the convolution processing.
         // That way we can still use it to control how the source signal downmixing takes place.
-        float spread = cosf(state->spatializerdata->spread * kPI / 360.0f);
+        float spread = cosf(state->spatializerdata->spread * AudioPluginUtil::kPI / 360.0f);
         float spreadmatrix[2] = { 2.0f - spread, spread };
 
         float* reverb = reverbmixbuffer;
@@ -244,7 +244,7 @@ namespace Spatializer
             for (int c = 0; c < 2; c++)
             {
                 // stereopan is in the [-1; 1] range, this acts the way fmod does it for stereo
-                float stereopan = 1.0f - ((c == 0) ? FastMax(0.0f, state->spatializerdata->stereopan) : FastMax(0.0f, -state->spatializerdata->stereopan));
+                float stereopan = 1.0f - ((c == 0) ? AudioPluginUtil::FastMax(0.0f, state->spatializerdata->stereopan) : AudioPluginUtil::FastMax(0.0f, -state->spatializerdata->stereopan));
 
                 InstanceChannel& ch = data->ch[c];
 
@@ -262,12 +262,12 @@ namespace Spatializer
                     ch.x[n].im = 0.0f;
                 }
 
-                FFT::Forward(ch.x, HRTFLEN * 2, false);
+                AudioPluginUtil::FFT::Forward(ch.x, HRTFLEN * 2, false);
 
                 for (int n = 0; n < HRTFLEN * 2; n++)
-                    UnityComplexNumber::Mul<float, float, float>(ch.x[n], ch.h[n], ch.y[n]);
+                    AudioPluginUtil::UnityComplexNumber::Mul<float, float, float>(ch.x[n], ch.h[n], ch.y[n]);
 
-                FFT::Backward(ch.y, HRTFLEN * 2, false);
+                AudioPluginUtil::FFT::Backward(ch.y, HRTFLEN * 2, false);
 
                 for (int n = 0; n < HRTFLEN; n++)
                 {

--- a/NativeCode/Plugin_SpatializerReverb.cpp
+++ b/NativeCode/Plugin_SpatializerReverb.cpp
@@ -122,12 +122,12 @@ namespace SpatializerReverb
             const InstanceChannel::Tap* tap_end = ch.taps + numtaps;
 
             float decay = powf(0.01f, 1.0f / (float)numtaps);
-            float p = 0.0f, amp = (decay - 1.0f) / (powf(decay, numtaps + 1) - 1.0f);
+            float p = 0.0f, amp = (decay - 1.0f) / (powf(decay, numtaps + 1.0f) - 1.0f);
             InstanceChannel::Tap* tap = ch.taps;
             while (tap != tap_end)
             {
                 p += data->random.GetFloat(0.0f, 100.0f);
-                tap->pos = p;
+                tap->pos = (int)p;
                 tap->amp = amp;
                 amp *= decay;
                 ++tap;
@@ -137,11 +137,11 @@ namespace SpatializerReverb
             tap = ch.taps;
             while (tap != tap_end)
             {
-                tap->pos *= scale;
+                tap->pos *= (int)scale;
                 ++tap;
             }
 
-            for (int n = 0; n < length; n++)
+            for (unsigned int n = 0; n < length; n++)
             {
                 ch.delay.Write(inbuffer[n * 2 + c] + reverbmixbuffer[n * 2 + c]);
 

--- a/NativeCode/Plugin_SpatializerReverb.cpp
+++ b/NativeCode/Plugin_SpatializerReverb.cpp
@@ -46,7 +46,7 @@ namespace SpatializerReverb
     struct EffectData
     {
         float p[P_NUM];
-        Random random;
+        AudioPluginUtil::Random random;
         InstanceChannel ch[2];
     };
 
@@ -54,8 +54,8 @@ namespace SpatializerReverb
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Delay Time", "", 0.0f, 5.0f, 2.0f, 1.0f, 1.0f, P_DELAYTIME, "Delay time in seconds");
-        RegisterParameter(definition, "Diffusion", "%", 0.0f, 1.0f, 0.5f, 100.0f, 1.0f, P_DIFFUSION, "Diffusion amount");
+        AudioPluginUtil::RegisterParameter(definition, "Delay Time", "", 0.0f, 5.0f, 2.0f, 1.0f, 1.0f, P_DELAYTIME, "Delay time in seconds");
+        AudioPluginUtil::RegisterParameter(definition, "Diffusion", "%", 0.0f, 1.0f, 0.5f, 100.0f, 1.0f, P_DIFFUSION, "Diffusion amount");
         return numparams;
     }
 
@@ -64,7 +64,7 @@ namespace SpatializerReverb
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_StereoWidener.cpp
+++ b/NativeCode/Plugin_StereoWidener.cpp
@@ -32,9 +32,9 @@ namespace StereoWidener
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Amount", "%", -10.0f, 10.0f, 1.0f, 100.0f, 1.0f, P_AMOUNT, "Amount of stereo widening applied. The default of 100% corresponds to the original stereo width of the input signal.");
-        RegisterParameter(definition, "Pre-delay", "ms", -0.0025f, 0.0025f, 0.0f, 1000.0f, 3.0f, P_PREDLY, "Pre-delay applied before the stereo widening.");
-        RegisterParameter(definition, "Post-delay", "ms", -0.0025f, 0.0025f, 0.0f, 1000.0f, 3.0f, P_POSTDLY, "Post-delay applied after the stereo widening.");
+        AudioPluginUtil::RegisterParameter(definition, "Amount", "%", -10.0f, 10.0f, 1.0f, 100.0f, 1.0f, P_AMOUNT, "Amount of stereo widening applied. The default of 100% corresponds to the original stereo width of the input signal.");
+        AudioPluginUtil::RegisterParameter(definition, "Pre-delay", "ms", -0.0025f, 0.0025f, 0.0f, 1000.0f, 3.0f, P_PREDLY, "Pre-delay applied before the stereo widening.");
+        AudioPluginUtil::RegisterParameter(definition, "Post-delay", "ms", -0.0025f, 0.0025f, 0.0f, 1000.0f, 3.0f, P_POSTDLY, "Post-delay applied after the stereo widening.");
         return numparams;
     }
 
@@ -43,7 +43,7 @@ namespace StereoWidener
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_StereoWidener.cpp
+++ b/NativeCode/Plugin_StereoWidener.cpp
@@ -49,8 +49,8 @@ namespace StereoWidener
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_Synthesizer.cpp
+++ b/NativeCode/Plugin_Synthesizer.cpp
@@ -219,7 +219,7 @@ namespace Synthesizer
             channels[1].Reset();
             this->p = p;
             this->sampletime = sampletime;
-            this->note = note;
+            this->note = (float)note;
             for (int i = 0; i < MAXOSCILLATORS; i++)
             {
                 channels[0].phase[i] = random.Get();
@@ -248,10 +248,10 @@ namespace Synthesizer
             float st = sampletime * (const float)(0x100000000 / OVERSAMPLING);
             float dt1 = p[P_DETUNE1] + 0.5f * p[P_DETUNE2];
             float dt2 = p[P_DETUNE1] - 0.5f * p[P_DETUNE2];
-            channels[0].freq = FreqFromNote(note - dt1) * st;
-            channels[1].freq = FreqFromNote(note - dt2) * st;
-            channels[0].detune = (FreqFromNote(note + dt1) * st - channels[0].freq) * ONE_OVER_MAXOSCILLATORS;
-            channels[1].detune = (FreqFromNote(note + dt2) * st - channels[1].freq) * ONE_OVER_MAXOSCILLATORS;
+            channels[0].freq = (UInt32)(FreqFromNote(note - dt1) * st);
+            channels[1].freq = (UInt32)(FreqFromNote(note - dt2) * st);
+            channels[0].detune = (UInt32)((FreqFromNote(note + dt1) * st - channels[0].freq) * ONE_OVER_MAXOSCILLATORS);
+            channels[1].detune = (UInt32)((FreqFromNote(note + dt2) * st - channels[1].freq) * ONE_OVER_MAXOSCILLATORS);
             channels[0].mask = ((UInt32)FastFloor(p[P_TYPE] * 127) + 128) << 24;
             channels[1].mask = ((UInt32)FastFloor(p[P_TYPE] * 127) + 128) << 24;
         }
@@ -344,7 +344,7 @@ namespace Synthesizer
                 Voice* v = voicepool[k];
                 v->FrameSetup();
                 float* dst = outbuffer;
-                for (unsigned int n = 0; n < length; n++)
+                for (int n = 0; n < length; n++)
                 {
                     v->Process(dst[0], dst[1]);
                     dst += outchannels;
@@ -528,7 +528,7 @@ namespace Synthesizer
                 }
                 data->numpending = j;
             }
-            int block = nextevent - currtick;
+            int block = (int)(nextevent - currtick);
             if (block == 0)
                 continue;
             if (block > samplesleft)

--- a/NativeCode/Plugin_TeeBee.cpp
+++ b/NativeCode/Plugin_TeeBee.cpp
@@ -40,7 +40,7 @@ namespace TeeBee
             float wetmix;
             float p[P_NUM];
             int pattern_index;
-            Random random;
+            AudioPluginUtil::Random random;
         };
         union
         {
@@ -53,29 +53,29 @@ namespace TeeBee
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Seed", "", 0.0f, 1000.0f, 0.0f, 1.0f, 1.0f, P_SEED, "Random seed that determines the pattern played.");
-        RegisterParameter(definition, "LowNote", "semitones", 0.0f, 100.0f, 24.0f, 1.0f, 1.0f, P_MINNOTE, "Deepest note in the pattern.");
-        RegisterParameter(definition, "HighNote", "semitones", 0.0f, 100.0f, 48.0f, 1.0f, 1.0f, P_MAXNOTE, "Highest note in the pattern.");
-        RegisterParameter(definition, "Cutoff", "Hz", 0.0f, kMaxSampleRate, 1000.0f, 1.0f, 3.0f, P_CUT, "Base cutoff frequency of resonant lowpass filter.");
-        RegisterParameter(definition, "Envelope", "Hz", 0.0f, kMaxSampleRate, 500.0f, 1.0f, 3.0f, P_ENV, "Amount of decay envelope applied to cutoff frequency.");
-        RegisterParameter(definition, "CutRnd", "Hz", 0.0f, kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_CUTRND, "Amount of cutoff randomization applied at note onset.");
-        RegisterParameter(definition, "EnvRnd", "Hz", 0.0f, kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_ENVRND, "Amount of randomization applied to cutoff envelope at note onset.");
-        RegisterParameter(definition, "Decay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_DECAY, "Decay time of cutoff envelope.");
-        RegisterParameter(definition, "Resonance", "%", 0.0f, 1.0f, 0.2f, 100.0f, 2.0f, P_RES, "Resonance amount of lowpass filter.");
-        RegisterParameter(definition, "Distortion", "%", 0.0f, 100.0f, 3.0f, 100.0f, 1.0f, P_DIST, "Amount of distortion applied after the resonant lowpass filter.");
-        RegisterParameter(definition, "Glide", "s", 0.001f, 1.0f, 0.01f, 1.0f, 3.0f, P_GLIDE, "Pitch glide time.");
-        RegisterParameter(definition, "BPM", "BPM", 10.0f, 300.0f, 120.0f, 1.0f, 1.0f, P_BPM, "Tempo of pattern in beats per minute.");
-        RegisterParameter(definition, "LFOFreq", "Hz", 0.0f, 50.0f, 0.1f, 1.0f, 3.0f, P_LFOFREQ, "Frequency of the low frequency oscillator that modulates the cutoff frequency of the resonant lowpass filter.");
-        RegisterParameter(definition, "LFOCut", "Hz", 0.0f, kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_LFOCUT, "Modulation amount of the low frequency oscillator that modulates the cutoff frequency of the resonant lowpass filter.");
-        RegisterParameter(definition, "LFOCutEnv", "Hz", 0.0f, kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_LFOCUTENV, "Modulation amount of the low frequency oscillator that modulates the envelope cutoff of the resonant lowpass filter.");
-        RegisterParameter(definition, "InputMix", "%", 0.0f, 100.0f, 100.0f, 1.0f, 1.0f, P_INPUTMIX, "Amount of input signal mixed to the output of the synthesizer.");
-        RegisterParameter(definition, "NumSteps", "", 1.0f, 64.0f, 16.0f, 1.0f, 1.0f, P_NUMSTEPS, "Number of steps in the played pattern.");
+        AudioPluginUtil::RegisterParameter(definition, "Seed", "", 0.0f, 1000.0f, 0.0f, 1.0f, 1.0f, P_SEED, "Random seed that determines the pattern played.");
+        AudioPluginUtil::RegisterParameter(definition, "LowNote", "semitones", 0.0f, 100.0f, 24.0f, 1.0f, 1.0f, P_MINNOTE, "Deepest note in the pattern.");
+        AudioPluginUtil::RegisterParameter(definition, "HighNote", "semitones", 0.0f, 100.0f, 48.0f, 1.0f, 1.0f, P_MAXNOTE, "Highest note in the pattern.");
+        AudioPluginUtil::RegisterParameter(definition, "Cutoff", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 1000.0f, 1.0f, 3.0f, P_CUT, "Base cutoff frequency of resonant lowpass filter.");
+        AudioPluginUtil::RegisterParameter(definition, "Envelope", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 500.0f, 1.0f, 3.0f, P_ENV, "Amount of decay envelope applied to cutoff frequency.");
+        AudioPluginUtil::RegisterParameter(definition, "CutRnd", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_CUTRND, "Amount of cutoff randomization applied at note onset.");
+        AudioPluginUtil::RegisterParameter(definition, "EnvRnd", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_ENVRND, "Amount of randomization applied to cutoff envelope at note onset.");
+        AudioPluginUtil::RegisterParameter(definition, "Decay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_DECAY, "Decay time of cutoff envelope.");
+        AudioPluginUtil::RegisterParameter(definition, "Resonance", "%", 0.0f, 1.0f, 0.2f, 100.0f, 2.0f, P_RES, "Resonance amount of lowpass filter.");
+        AudioPluginUtil::RegisterParameter(definition, "Distortion", "%", 0.0f, 100.0f, 3.0f, 100.0f, 1.0f, P_DIST, "Amount of distortion applied after the resonant lowpass filter.");
+        AudioPluginUtil::RegisterParameter(definition, "Glide", "s", 0.001f, 1.0f, 0.01f, 1.0f, 3.0f, P_GLIDE, "Pitch glide time.");
+        AudioPluginUtil::RegisterParameter(definition, "BPM", "BPM", 10.0f, 300.0f, 120.0f, 1.0f, 1.0f, P_BPM, "Tempo of pattern in beats per minute.");
+        AudioPluginUtil::RegisterParameter(definition, "LFOFreq", "Hz", 0.0f, 50.0f, 0.1f, 1.0f, 3.0f, P_LFOFREQ, "Frequency of the low frequency oscillator that modulates the cutoff frequency of the resonant lowpass filter.");
+        AudioPluginUtil::RegisterParameter(definition, "LFOCut", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_LFOCUT, "Modulation amount of the low frequency oscillator that modulates the cutoff frequency of the resonant lowpass filter.");
+        AudioPluginUtil::RegisterParameter(definition, "LFOCutEnv", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 0.0f, 1.0f, 3.0f, P_LFOCUTENV, "Modulation amount of the low frequency oscillator that modulates the envelope cutoff of the resonant lowpass filter.");
+        AudioPluginUtil::RegisterParameter(definition, "InputMix", "%", 0.0f, 100.0f, 100.0f, 1.0f, 1.0f, P_INPUTMIX, "Amount of input signal mixed to the output of the synthesizer.");
+        AudioPluginUtil::RegisterParameter(definition, "NumSteps", "", 1.0f, 64.0f, 16.0f, 1.0f, 1.0f, P_NUMSTEPS, "Number of steps in the played pattern.");
         return numparams;
     }
 
     static void CalcPattern(EffectData::Data* data)
     {
-        Random random;
+        AudioPluginUtil::Random random;
         random.Seed((unsigned long)(data->p[P_SEED] * 1000));
         for (int i = 0; i < 64; i++)
         {
@@ -89,7 +89,7 @@ namespace TeeBee
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         CalcPattern(&effectdata->data);
         return UNITY_AUDIODSP_OK;
     }
@@ -151,18 +151,18 @@ namespace TeeBee
                 data->cutrnd = data->random.GetFloat(0.0f, data->p[P_CUTRND]);
             }
             data->phase += data->freq;
-            data->phase -= FastFloor(data->phase);
+            data->phase -= AudioPluginUtil::FastFloor(data->phase);
             data->lfophase += data->p[P_LFOFREQ] * st;
-            data->lfophase -= FastFloor(data->lfophase);
+            data->lfophase -= AudioPluginUtil::FastFloor(data->lfophase);
             data->freq += (data->pattern[data->pattern_index] * st - data->freq) * glide;
             float outval = data->phase * 2.0f - 1.0f;
-            float lfocut = 0.5f + 0.5f * sinf(data->lfophase * 2.0f * kPI);
+            float lfocut = 0.5f + 0.5f * sinf(data->lfophase * 2.0f * AudioPluginUtil::kPI);
             float cut = data->p[P_CUT] + data->cutrnd + data->env + lfocut * (data->p[P_LFOCUT] + data->lfoenv * data->p[P_LFOCUTENV]);
             if (cut < 0.0f)
                 cut = 0.0f;
             else if (cut > max_cut)
                 cut = max_cut;
-            cut = 2.0f * sinf(0.5f * kPI * cut * st);
+            cut = 2.0f * sinf(0.5f * AudioPluginUtil::kPI * cut * st);
             if (cut > 1.4f)
                 cut = 1.4f;
             float bw = 1.0f - data->p[P_RES];
@@ -173,7 +173,7 @@ namespace TeeBee
             tmp = 0.5f * cut * (outval - data->lpf - data->bpf * bw);
             float bpf_out = data->bpf + tmp; data->bpf = bpf_out + tmp;
             data->wetmix += (wetTarget - data->wetmix) * 0.05f + 1.0e-9f;
-            outval = atanf(lpf_out * data->p[P_DIST]) * (1.0f / kPI);
+            outval = atanf(lpf_out * data->p[P_DIST]) * (1.0f / AudioPluginUtil::kPI);
             for (int i = 0; i < outchannels; i++)
             {
                 float inval = inbuffer[n * inchannels + i];

--- a/NativeCode/Plugin_TeeBee.cpp
+++ b/NativeCode/Plugin_TeeBee.cpp
@@ -96,8 +96,8 @@ namespace TeeBee
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_TeeDee.cpp
+++ b/NativeCode/Plugin_TeeDee.cpp
@@ -104,8 +104,8 @@ namespace TeeDee
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_TeeDee.cpp
+++ b/NativeCode/Plugin_TeeDee.cpp
@@ -39,7 +39,7 @@ namespace TeeDee
             float wetmix;
             float p[P_NUM];
             int pattern_index;
-            Random random;
+            AudioPluginUtil::Random random;
         };
         union
         {
@@ -52,31 +52,31 @@ namespace TeeDee
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Seed", "", 0.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_SEED, "Random seed of the pattern played. The first 5 patterns are pre-defined typical rhythm patterns.");
-        RegisterParameter(definition, "BPM", "BPM", 10.0f, 300.0f, 120.0f, 1.0f, 1.0f, P_BPM, "Tempo of the played pattern in beats per minute.");
-        RegisterParameter(definition, "Sine", "%", 0.0f, 1.0f, 1.0f, 100.0f, 1.0f, P_SINE, "Amount of sine oscillator.");
-        RegisterParameter(definition, "Noise", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_NOISE, "Amount of noise generator.");
-        RegisterParameter(definition, "Cutoff", "Hz", 0.0f, kMaxSampleRate, 1000.0f, 1.0f, 3.0f, P_CUT, "Base cutoff frequency of resonant lowpass/highpass filter");
-        RegisterParameter(definition, "Resonance", "%", 0.0f, 1.0f, 0.2f, 100.0f, 3.0f, P_RES, "Resonance amount of filter.");
-        RegisterParameter(definition, "Freq", "Hz", 0.0f, 1000.0f, 200.0f, 1.0f, 3.0f, P_FREQ, "Base frequency of sine oscillator.");
-        RegisterParameter(definition, "AmpDecay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_ADECAY, "Amplitude decay time in seconds.");
-        RegisterParameter(definition, "FilterDecay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_FDECAY, "Frequency decay time in seconds.");
-        RegisterParameter(definition, "PitchDecay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_PDECAY, "Pitch decay time in seconds.");
-        RegisterParameter(definition, "FilterType", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_FILTERTYPE, "Mix ratio between lowpass and highpass filters.");
-        RegisterParameter(definition, "Distortion", "%", 0.0f, 100.0f, 3.0f, 100.0f, 1.0f, P_POSTDIST, "Amount of distortion applied after the resonant filter.");
-        RegisterParameter(definition, "AmpEnv", "%", 0.0f, 1.0f, 1.0f, 100.0f, 1.0f, P_AENV, "Amplitude envelope amount.");
-        RegisterParameter(definition, "FilterEnv", "%", 0.0f, kMaxSampleRate, 5000.0f, 1.0f, 3.0f, P_FENV, "Frequency envelope amount.");
-        RegisterParameter(definition, "PitchEnv", "%", 0.0f, 1000.0f, 0.0f, 100.0f, 1.0f, P_PENV, "Pitch envelope amount.");
-        RegisterParameter(definition, "PreDist", "%", 0.0f, 100.0f, 1.0f, 100.0f, 1.0f, P_PREDIST, "Distortion applied before the resonant filter.");
-        RegisterParameter(definition, "InputMix", "%", 0.0f, 100.0f, 100.0f, 1.0f, 1.0f, P_INPUTMIX, "Amount of input signals mixed to the output of the synthesizer.");
-        RegisterParameter(definition, "NumSteps", "", 1.0f, 64.0f, 16.0f, 1.0f, 1.0f, P_NUMSTEPS, "Number of steps in the played pattern.");
+        AudioPluginUtil::RegisterParameter(definition, "Seed", "", 0.0f, 100.0f, 0.0f, 1.0f, 1.0f, P_SEED, "Random seed of the pattern played. The first 5 patterns are pre-defined typical rhythm patterns.");
+        AudioPluginUtil::RegisterParameter(definition, "BPM", "BPM", 10.0f, 300.0f, 120.0f, 1.0f, 1.0f, P_BPM, "Tempo of the played pattern in beats per minute.");
+        AudioPluginUtil::RegisterParameter(definition, "Sine", "%", 0.0f, 1.0f, 1.0f, 100.0f, 1.0f, P_SINE, "Amount of sine oscillator.");
+        AudioPluginUtil::RegisterParameter(definition, "Noise", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_NOISE, "Amount of noise generator.");
+        AudioPluginUtil::RegisterParameter(definition, "Cutoff", "Hz", 0.0f, AudioPluginUtil::kMaxSampleRate, 1000.0f, 1.0f, 3.0f, P_CUT, "Base cutoff frequency of resonant lowpass/highpass filter");
+        AudioPluginUtil::RegisterParameter(definition, "Resonance", "%", 0.0f, 1.0f, 0.2f, 100.0f, 3.0f, P_RES, "Resonance amount of filter.");
+        AudioPluginUtil::RegisterParameter(definition, "Freq", "Hz", 0.0f, 1000.0f, 200.0f, 1.0f, 3.0f, P_FREQ, "Base frequency of sine oscillator.");
+        AudioPluginUtil::RegisterParameter(definition, "AmpDecay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_ADECAY, "Amplitude decay time in seconds.");
+        AudioPluginUtil::RegisterParameter(definition, "FilterDecay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_FDECAY, "Frequency decay time in seconds.");
+        AudioPluginUtil::RegisterParameter(definition, "PitchDecay", "s", 0.0f, 5.0f, 0.5f, 1.0f, 3.0f, P_PDECAY, "Pitch decay time in seconds.");
+        AudioPluginUtil::RegisterParameter(definition, "FilterType", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_FILTERTYPE, "Mix ratio between lowpass and highpass filters.");
+        AudioPluginUtil::RegisterParameter(definition, "Distortion", "%", 0.0f, 100.0f, 3.0f, 100.0f, 1.0f, P_POSTDIST, "Amount of distortion applied after the resonant filter.");
+        AudioPluginUtil::RegisterParameter(definition, "AmpEnv", "%", 0.0f, 1.0f, 1.0f, 100.0f, 1.0f, P_AENV, "Amplitude envelope amount.");
+        AudioPluginUtil::RegisterParameter(definition, "FilterEnv", "%", 0.0f, AudioPluginUtil::kMaxSampleRate, 5000.0f, 1.0f, 3.0f, P_FENV, "Frequency envelope amount.");
+        AudioPluginUtil::RegisterParameter(definition, "PitchEnv", "%", 0.0f, 1000.0f, 0.0f, 100.0f, 1.0f, P_PENV, "Pitch envelope amount.");
+        AudioPluginUtil::RegisterParameter(definition, "PreDist", "%", 0.0f, 100.0f, 1.0f, 100.0f, 1.0f, P_PREDIST, "Distortion applied before the resonant filter.");
+        AudioPluginUtil::RegisterParameter(definition, "InputMix", "%", 0.0f, 100.0f, 100.0f, 1.0f, 1.0f, P_INPUTMIX, "Amount of input signals mixed to the output of the synthesizer.");
+        AudioPluginUtil::RegisterParameter(definition, "NumSteps", "", 1.0f, 64.0f, 16.0f, 1.0f, 1.0f, P_NUMSTEPS, "Number of steps in the played pattern.");
         return numparams;
     }
 
     static void CalcPattern(EffectData::Data* data)
     {
         int seed = (int)data->p[P_SEED];
-        Random random;
+        AudioPluginUtil::Random random;
         random.Seed((unsigned long)(seed * 1000));
         for (int i = 0; i < 64; i++)
         {
@@ -97,7 +97,7 @@ namespace TeeDee
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         CalcPattern(&effectdata->data);
         return UNITY_AUDIODSP_OK;
     }
@@ -163,18 +163,18 @@ namespace TeeDee
                 }
             }
             data->phase += (data->p[P_FREQ] + data->penv) * st;
-            data->phase -= FastFloor(data->phase);
+            data->phase -= AudioPluginUtil::FastFloor(data->phase);
             data->aenv = data->aenv * adecay + 1.0e-11f;
             data->fenv = data->fenv * fdecay + 1.0e-11f;
             data->penv = data->penv * pdecay + 1.0e-11f;
-            float outval = sinf(data->phase * 2.0f * kPI) * data->p[P_SINE] + data->random.GetFloat(-1.0f, 1.0f) * data->p[P_NOISE];
-            outval = atanf(outval * data->p[P_PREDIST]) * (1.0f / kPI) * data->aenv;
+            float outval = sinf(data->phase * 2.0f * AudioPluginUtil::kPI) * data->p[P_SINE] + data->random.GetFloat(-1.0f, 1.0f) * data->p[P_NOISE];
+            outval = atanf(outval * data->p[P_PREDIST]) * (1.0f / AudioPluginUtil::kPI) * data->aenv;
             float cut = data->p[P_CUT] + data->fenv;
             if (cut < 0.0f)
                 cut = 0.0f;
             else if (cut > sr_half)
                 cut = sr_half;
-            cut = 2.0f * sinf(0.5f * kPI * cut * st);
+            cut = 2.0f * sinf(0.5f * AudioPluginUtil::kPI * cut * st);
             if (cut > 1.4f)
                 cut = 1.4f;
             float bw = 1.0f - data->p[P_RES]; bw *= bw;
@@ -183,7 +183,7 @@ namespace TeeDee
             data->bpf += cut * hpf;
             data->wetmix += (wetTarget - data->wetmix) * 0.05f + 1.0e-9f;
             outval = data->lpf + (hpf - data->lpf) * data->p[P_FILTERTYPE];
-            outval = atanf(outval * data->p[P_POSTDIST]) * (1.0f / kPI) * data->aenv;
+            outval = atanf(outval * data->p[P_POSTDIST]) * (1.0f / AudioPluginUtil::kPI) * data->aenv;
             for (int i = 0; i < outchannels; i++)
             {
                 float inval = inbuffer[n * inchannels + i];

--- a/NativeCode/Plugin_Teleport.cpp
+++ b/NativeCode/Plugin_Teleport.cpp
@@ -28,14 +28,14 @@ namespace Teleport
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Stream", "", 0.0f, 7.0f, 0.0f, 1.0f, 1.0f, P_STREAM, "External audio stream to read from or write to.");
-        RegisterParameter(definition, "Send", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_SEND, "Gain of signal sent to the external audio stream.");
-        RegisterParameter(definition, "Input Gain", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_INPUTGAIN, "Gain of signal passing through effect.");
-        RegisterParameter(definition, "Teleport Gain", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_TELEPORTGAIN, "Gain of the received external audio stream.");
-        RegisterParameter(definition, "Param1", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM1, "User-defined parameter 1 (read/write)");
-        RegisterParameter(definition, "Param2", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM2, "User-defined parameter 2 (read/write)");
-        RegisterParameter(definition, "Param3", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM3, "User-defined parameter 3 (read/write)");
-        RegisterParameter(definition, "Param4", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM4, "User-defined parameter 4 (read/write)");
+        AudioPluginUtil::RegisterParameter(definition, "Stream", "", 0.0f, 7.0f, 0.0f, 1.0f, 1.0f, P_STREAM, "External audio stream to read from or write to.");
+        AudioPluginUtil::RegisterParameter(definition, "Send", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_SEND, "Gain of signal sent to the external audio stream.");
+        AudioPluginUtil::RegisterParameter(definition, "Input Gain", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_INPUTGAIN, "Gain of signal passing through effect.");
+        AudioPluginUtil::RegisterParameter(definition, "Teleport Gain", "", 0.0f, 1.0f, 1.0f, 1.0f, 1.0f, P_TELEPORTGAIN, "Gain of the received external audio stream.");
+        AudioPluginUtil::RegisterParameter(definition, "Param1", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM1, "User-defined parameter 1 (read/write)");
+        AudioPluginUtil::RegisterParameter(definition, "Param2", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM2, "User-defined parameter 2 (read/write)");
+        AudioPluginUtil::RegisterParameter(definition, "Param3", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM3, "User-defined parameter 3 (read/write)");
+        AudioPluginUtil::RegisterParameter(definition, "Param4", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_PARAM4, "User-defined parameter 4 (read/write)");
         return numparams;
     }
 
@@ -44,7 +44,7 @@ namespace Teleport
         EffectData* data = new EffectData;
         memset(data, 0, sizeof(EffectData));
         state->effectdata = data;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, data->p);
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_TubeResonator.cpp
+++ b/NativeCode/Plugin_TubeResonator.cpp
@@ -65,7 +65,7 @@ namespace TubeResonator
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Num sections", "", 1.0f, MAXSECTIONS, 3.0f, 1.0f, 1.0f, P_NUMSECTIONS, "Number of sections");
+        RegisterParameter(definition, "Num sections", "", 1.0f, (float)MAXSECTIONS, 3.0f, 1.0f, 1.0f, P_NUMSECTIONS, "Number of sections");
         RegisterParameter(definition, "Feedback", "%", 0.0f, 1.0f, 0.5f, 100.0f, 1.0f, P_FB, "Feedback");
         RegisterParameter(definition, "Nonlinearity", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_NL, "Amount of nonlinearity at reflection");
         RegisterParameter(definition, "Mike position", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_MIKEPOS, "Microphone position");

--- a/NativeCode/Plugin_TubeResonator.cpp
+++ b/NativeCode/Plugin_TubeResonator.cpp
@@ -27,7 +27,7 @@ namespace TubeResonator
         {
             data[writepos] = input;
             float f = writepos + MASK - delay;
-            int r = FastFloor(f);
+            int r = AudioPluginUtil::FastFloor(f);
             f -= r;
             r &= MASK;
             writepos = (writepos + 1) & MASK;
@@ -65,14 +65,14 @@ namespace TubeResonator
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Num sections", "", 1.0f, (float)MAXSECTIONS, 3.0f, 1.0f, 1.0f, P_NUMSECTIONS, "Number of sections");
-        RegisterParameter(definition, "Feedback", "%", 0.0f, 1.0f, 0.5f, 100.0f, 1.0f, P_FB, "Feedback");
-        RegisterParameter(definition, "Nonlinearity", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_NL, "Amount of nonlinearity at reflection");
-        RegisterParameter(definition, "Mike position", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_MIKEPOS, "Microphone position");
+        AudioPluginUtil::RegisterParameter(definition, "Num sections", "", 1.0f, (float)MAXSECTIONS, 3.0f, 1.0f, 1.0f, P_NUMSECTIONS, "Number of sections");
+        AudioPluginUtil::RegisterParameter(definition, "Feedback", "%", 0.0f, 1.0f, 0.5f, 100.0f, 1.0f, P_FB, "Feedback");
+        AudioPluginUtil::RegisterParameter(definition, "Nonlinearity", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_NL, "Amount of nonlinearity at reflection");
+        AudioPluginUtil::RegisterParameter(definition, "Mike position", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_MIKEPOS, "Microphone position");
         for (int n = 0; n < MAXSECTIONS; n++)
         {
-            RegisterParameter(definition, tmpstr(0, "Length %d", n + 1), "cm", 0.01f, (float)Delay::MASK * (34000.0f / 48000.0f), 7.0f, 1.0f, 3.0f, P_L1 + n * 2, tmpstr(1, "Section %d length", n + 1));
-            RegisterParameter(definition, tmpstr(0, "Radius %d", n + 1), "cm", 0.01f, 100.0f, 3.0f, 1.0f, 3.0f, P_A1 + n * 2, tmpstr(1, "Section %d radius", n + 1));
+            AudioPluginUtil::RegisterParameter(definition, AudioPluginUtil::tmpstr(0, "Length %d", n + 1), "cm", 0.01f, (float)Delay::MASK * (34000.0f / 48000.0f), 7.0f, 1.0f, 3.0f, P_L1 + n * 2, AudioPluginUtil::tmpstr(1, "Section %d length", n + 1));
+            AudioPluginUtil::RegisterParameter(definition, AudioPluginUtil::tmpstr(0, "Radius %d", n + 1), "cm", 0.01f, 100.0f, 3.0f, 1.0f, 3.0f, P_A1 + n * 2, AudioPluginUtil::tmpstr(1, "Section %d radius", n + 1));
         }
         return numparams;
     }
@@ -82,7 +82,7 @@ namespace TubeResonator
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 
@@ -151,7 +151,7 @@ namespace TubeResonator
             for (unsigned int n = 0; n < length; n++)
             {
                 float refl = ch.section[numsections - 1].upper.output;
-                float r = FastMin(refl * refl, 1.0f);
+                float r = AudioPluginUtil::FastMin(refl * refl, 1.0f);
                 refl += (r * refl - refl) * nl;
                 ch.section[0].upper.input = ch.section[0].lower.output + *src;
                 ch.section[numsections - 1].lower.input = refl * fb;

--- a/NativeCode/Plugin_TubeResonator.cpp
+++ b/NativeCode/Plugin_TubeResonator.cpp
@@ -88,8 +88,8 @@ namespace TubeResonator
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 

--- a/NativeCode/Plugin_Vocoder.cpp
+++ b/NativeCode/Plugin_Vocoder.cpp
@@ -26,10 +26,10 @@ namespace Vocoder
 
     struct Band
     {
-        StateVariableFilter analysis1;
-        StateVariableFilter analysis2;
-        StateVariableFilter synthesis1;
-        StateVariableFilter synthesis2;
+        AudioPluginUtil::StateVariableFilter analysis1;
+        AudioPluginUtil::StateVariableFilter analysis2;
+        AudioPluginUtil::StateVariableFilter synthesis1;
+        AudioPluginUtil::StateVariableFilter synthesis2;
         EnvFollower envfollow;
     };
 
@@ -53,13 +53,13 @@ namespace Vocoder
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Gain", "dB", -100.0f, 20.0f, -30.0f, 1.0f, 1.0f, P_GAIN, "Overall gain.");
-        RegisterParameter(definition, "Formant Shift", "Hz", -1500.0f, 1500.0f, 0.0f, 1.0f, 3.0f, P_FMTSHIFT, "Relative shifting of filterbank center frequencies.");
-        RegisterParameter(definition, "Formant Scale", "x", 0.05f, 10.0f, 1.0f, 1.0f, 3.0f, P_FMTSCALE, "Scaling of filterbank center frequencies.");
-        RegisterParameter(definition, "Analysis BW", "%", 0.001f, 1.0f, 0.1f, 100.0f, 1.0f, P_ANALYSISBW, "Analysis filterbank bandwidth.");
-        RegisterParameter(definition, "Synthesis BW", "%", 0.001f, 1.0f, 0.1f, 100.0f, 1.0f, P_SYNTHESISBW, "Synthesis filterbank bandwidth.");
-        RegisterParameter(definition, "Envelope Decay", "s", 0.001f, 0.4f, 0.01f, 1.0f, 1.0f, P_ENVDECAY, "Envelope follower decay time. Inversely proportional to the speed at which changes are detected.");
-        RegisterParameter(definition, "Emphasis", "%", 0.5f, 1.5f, 1.2f, 100.0f, 1.0f, P_EMPHASIS, "Emphasis amount. Can be used to tilt the filter bank to improve intelligibility of consonants.");
+        AudioPluginUtil::RegisterParameter(definition, "Gain", "dB", -100.0f, 20.0f, -30.0f, 1.0f, 1.0f, P_GAIN, "Overall gain.");
+        AudioPluginUtil::RegisterParameter(definition, "Formant Shift", "Hz", -1500.0f, 1500.0f, 0.0f, 1.0f, 3.0f, P_FMTSHIFT, "Relative shifting of filterbank center frequencies.");
+        AudioPluginUtil::RegisterParameter(definition, "Formant Scale", "x", 0.05f, 10.0f, 1.0f, 1.0f, 3.0f, P_FMTSCALE, "Scaling of filterbank center frequencies.");
+        AudioPluginUtil::RegisterParameter(definition, "Analysis BW", "%", 0.001f, 1.0f, 0.1f, 100.0f, 1.0f, P_ANALYSISBW, "Analysis filterbank bandwidth.");
+        AudioPluginUtil::RegisterParameter(definition, "Synthesis BW", "%", 0.001f, 1.0f, 0.1f, 100.0f, 1.0f, P_SYNTHESISBW, "Synthesis filterbank bandwidth.");
+        AudioPluginUtil::RegisterParameter(definition, "Envelope Decay", "s", 0.001f, 0.4f, 0.01f, 1.0f, 1.0f, P_ENVDECAY, "Envelope follower decay time. Inversely proportional to the speed at which changes are detected.");
+        AudioPluginUtil::RegisterParameter(definition, "Emphasis", "%", 0.5f, 1.5f, 1.2f, 100.0f, 1.0f, P_EMPHASIS, "Emphasis amount. Can be used to tilt the filter bank to improve intelligibility of consonants.");
         definition.flags |= UnityAudioEffectDefinitionFlags_IsSideChainTarget;
         return numparams;
     }
@@ -69,7 +69,7 @@ namespace Vocoder
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 
@@ -114,7 +114,7 @@ namespace Vocoder
         float gain = powf(10.0f, 0.05f * data->p[P_GAIN] + 2.5f);
         float maxfreq = 0.25f * state->samplerate;
         float sampletime = 1.0f / (float)state->samplerate;
-        float w0 = 0.5f * kPI * sampletime;
+        float w0 = 0.5f * AudioPluginUtil::kPI * sampletime;
         float envdecay = 1.0f - powf(0.001f, sampletime / data->p[P_ENVDECAY]);
         float emph = data->p[P_EMPHASIS];
         for (int j = 0; j < NUMBANDS; j++)

--- a/NativeCode/Plugin_Vocoder.cpp
+++ b/NativeCode/Plugin_Vocoder.cpp
@@ -75,8 +75,8 @@ namespace Vocoder
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 
@@ -111,7 +111,7 @@ namespace Vocoder
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ProcessCallback(UnityAudioEffectState* state, float* inbuffer, float* outbuffer, unsigned int length, int inchannels, int outchannels)
     {
         EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        float gain = powf(10.0f, 0.05f * data->p[P_GAIN] + 2.5);
+        float gain = powf(10.0f, 0.05f * data->p[P_GAIN] + 2.5f);
         float maxfreq = 0.25f * state->samplerate;
         float sampletime = 1.0f / (float)state->samplerate;
         float w0 = 0.5f * kPI * sampletime;

--- a/NativeCode/Plugin_WahWah.cpp
+++ b/NativeCode/Plugin_WahWah.cpp
@@ -22,8 +22,8 @@ namespace WahWah
             float p[P_NUM];
             struct Channel
             {
-                StateVariableFilter filter1;
-                StateVariableFilter filter2;
+                AudioPluginUtil::StateVariableFilter filter1;
+                AudioPluginUtil::StateVariableFilter filter2;
                 float env;
             } channels[8];
         };
@@ -38,14 +38,14 @@ namespace WahWah
     {
         int numparams = P_NUM;
         definition.paramdefs = new UnityAudioParameterDefinition[numparams];
-        RegisterParameter(definition, "Attack Time", "s", 0.001f, 2.0f, 0.1f, 1.0f, 3.0f, P_ATK, "Attack time");
-        RegisterParameter(definition, "Release Time", "s", 0.001f, 2.0f, 0.5f, 1.0f, 3.0f, P_REL, "Release time");
-        RegisterParameter(definition, "Base Level", "%", 0.0f, 1.0f, 0.1f, 100.0f, 1.0f, P_BASE, "Base filter level");
-        RegisterParameter(definition, "Sensitivity", "%", -1.0f, 1.0f, 0.1f, 100.0f, 1.0f, P_SENS, "Filter sensitivity");
-        RegisterParameter(definition, "Resonance", "%", 0.0f, 1.0f, 0.1f, 100.0f, 1.0f, P_RESO, "Filter resonance");
-        RegisterParameter(definition, "Type", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_TYPE, "Filter type (0 = lowpass, 1 = bandpass)");
-        RegisterParameter(definition, "Depth", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_DEPTH, "Filter depth (0 = 12 dB, 1 = 24 dB)");
-        RegisterParameter(definition, "Sidechain Mix", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_SIDECHAIN, "Sidechain mix (0 = use input, 1 = use sidechain)");
+        AudioPluginUtil::RegisterParameter(definition, "Attack Time", "s", 0.001f, 2.0f, 0.1f, 1.0f, 3.0f, P_ATK, "Attack time");
+        AudioPluginUtil::RegisterParameter(definition, "Release Time", "s", 0.001f, 2.0f, 0.5f, 1.0f, 3.0f, P_REL, "Release time");
+        AudioPluginUtil::RegisterParameter(definition, "Base Level", "%", 0.0f, 1.0f, 0.1f, 100.0f, 1.0f, P_BASE, "Base filter level");
+        AudioPluginUtil::RegisterParameter(definition, "Sensitivity", "%", -1.0f, 1.0f, 0.1f, 100.0f, 1.0f, P_SENS, "Filter sensitivity");
+        AudioPluginUtil::RegisterParameter(definition, "Resonance", "%", 0.0f, 1.0f, 0.1f, 100.0f, 1.0f, P_RESO, "Filter resonance");
+        AudioPluginUtil::RegisterParameter(definition, "Type", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_TYPE, "Filter type (0 = lowpass, 1 = bandpass)");
+        AudioPluginUtil::RegisterParameter(definition, "Depth", "", 0.0f, 1.0f, 0.0f, 1.0f, 1.0f, P_DEPTH, "Filter depth (0 = 12 dB, 1 = 24 dB)");
+        AudioPluginUtil::RegisterParameter(definition, "Sidechain Mix", "%", 0.0f, 1.0f, 0.0f, 100.0f, 1.0f, P_SIDECHAIN, "Sidechain mix (0 = use input, 1 = use sidechain)");
         definition.flags |= UnityAudioEffectDefinitionFlags_IsSideChainTarget;
         return numparams;
     }
@@ -55,7 +55,7 @@ namespace WahWah
         EffectData* effectdata = new EffectData;
         memset(effectdata, 0, sizeof(EffectData));
         state->effectdata = effectdata;
-        InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
+        AudioPluginUtil::InitParametersFromDefinitions(InternalRegisterEffectDefinition, effectdata->data.p);
         return UNITY_AUDIODSP_OK;
     }
 
@@ -115,7 +115,7 @@ namespace WahWah
                 float s = *src;
                 float a = fabsf(s + (*sc - s) * data->p[P_SIDECHAIN]);
                 ch.env += (a - ch.env) * ((a > ch.env) ? atkconst : relconst);
-                ch.filter1.cutoff = FastClip(data->p[P_BASE] + ch.env * data->p[P_SENS], 0.0f, 1.4f);
+                ch.filter1.cutoff = AudioPluginUtil::FastClip(data->p[P_BASE] + ch.env * data->p[P_SENS], 0.0f, 1.4f);
                 ch.filter2.cutoff = ch.filter1.cutoff;
                 ch.filter2.ProcessLPF(ch.filter1.ProcessLPF(*src));
                 float lpf = ch.filter1.lpf + (ch.filter2.lpf - ch.filter1.lpf) * data->p[P_DEPTH];

--- a/NativeCode/Plugin_WahWah.cpp
+++ b/NativeCode/Plugin_WahWah.cpp
@@ -61,8 +61,8 @@ namespace WahWah
 
     UNITY_AUDIODSP_RESULT UNITY_AUDIODSP_CALLBACK ReleaseCallback(UnityAudioEffectState* state)
     {
-        EffectData::Data* data = &state->GetEffectData<EffectData>()->data;
-        delete data;
+        EffectData* effectdata = state->GetEffectData<EffectData>();
+        delete effectdata;
         return UNITY_AUDIODSP_OK;
     }
 


### PR DESCRIPTION
- Fix class name conflicts between dll and player (e.g. class Mutex) 
I've added namespace AudioPluginUtil. Because "class Mutex" has cuased name conflicts between dll & player. In some platform, it'll cause some crashes.

- Fix new / delete mismatching(effectdata is correct in some case)
I've found new / delete mismatching.  (data <> effectdata)

- Fix compiler warning about numeric casting (int to float, int to unsigned int, ...)
I'd prefer to fix it because it'll dismiss important notices.

- Support PlatformMutex
I've added to support PlatformMutex for any other platforms. This future is disabled by default.