### PR TITLE
UNITY_AUDIODSP_EXPORT_API sets default visibility

### DIFF
--- a/NativeCode/AudioPluginInterface.h
+++ b/NativeCode/AudioPluginInterface.h
@@ -154,7 +154,7 @@ typedef signed long long SInt64;
 #if PLATFORM_WIN
     #define UNITY_AUDIODSP_EXPORT_API __declspec(dllexport)
 #else
-    #define UNITY_AUDIODSP_EXPORT_API
+    #define UNITY_AUDIODSP_EXPORT_API __attribute__((visibility("default")))
 #endif
 
 #if defined(__CYGWIN32__)

--- a/NativeCode/Makefile
+++ b/NativeCode/Makefile
@@ -28,7 +28,7 @@ Plugin_WahWah.cpp \
 hrtftable.cpp
 OBJS=$(SRCS:.cpp=.o)
 OUTPUT=libAudioPluginDemo.so
-CXXFLAGS=-I. -O2 -fPIC
+CXXFLAGS=-I. -O2 -fPIC -fvisibility=hidden -Wno-attributes
 LDFLAGS=-shared -rdynamic -fPIC
 CXX=g++
 

--- a/NativeCode/TeleportLib.h
+++ b/NativeCode/TeleportLib.h
@@ -1,11 +1,5 @@
 #pragma once
 
-#if UNITY_WIN
-#define UNITY_AUDIODSP_EXPORT_API __declspec(dllexport)
-#else
-#define UNITY_AUDIODSP_EXPORT_API
-#endif
-
 extern "C"
 {
 typedef UNITY_AUDIODSP_EXPORT_API int (*TeleportFeedFunc)(int stream, float* samples, int numsamples);


### PR DESCRIPTION
Fixes #6

Verified symbol visibility on Linux, checked it doesn't regress the Windows build